### PR TITLE
新增了三篇经典 Neural Combinatorial Optimization 论文，并按照仓库现有格式整理为 specialist solver notes：

### DIFF
--- a/specialist/README.md
+++ b/specialist/README.md
@@ -45,6 +45,33 @@ Select a paper title to open its research note.
 - **Year:** 2019
 - **First public:** 2018-03-22
 - **Institutions:** University of Amsterdam; ORTEC; CIFAR
+
+### [Reinforcement Learning for Solving the Vehicle Routing Problem](rl-vrp.md)
+
+- **Paradigm:** Constructive
+- **Problems:** Vehicle Routing Problem; Capacitated Vehicle Routing Problem
+- **Venue:** NeurIPS
+- **Year:** 2018
+- **First public:** 2018-02-12
+- **Institutions:** Lehigh University
+
+### [Learning Combinatorial Optimization Algorithms over Graphs](learning-co-over-graphs.md)
+
+- **Paradigm:** Constructive
+- **Problems:** Minimum Vertex Cover; Maximum Cut; Traveling Salesman Problem
+- **Venue:** NIPS
+- **Year:** 2017
+- **First public:** 2017-04-05
+- **Institutions:** Georgia Institute of Technology; Ant Financial
+
+### [Neural Combinatorial Optimization with Reinforcement Learning](neural-combinatorial-optimization.md)
+
+- **Paradigm:** Constructive
+- **Problems:** Traveling Salesman Problem; Knapsack Problem
+- **Venue:** ICLR
+- **Year:** 2017
+- **First public:** 2016-11-29
+- **Institutions:** Google Brain
 <!-- GENERATED_PAPER_INDEX_END -->
 
 ## Adding a Specialist Solver

--- a/specialist/learning-co-over-graphs.md
+++ b/specialist/learning-co-over-graphs.md
@@ -1,0 +1,89 @@
+---
+id: learning-co-over-graphs
+short_title: S2V-DQN
+title: 'Learning Combinatorial Optimization Algorithms over Graphs'
+authors:
+  - Hanjun Dai
+  - Elias B. Khalil
+  - Yuyu Zhang
+  - Bistra Dilkina
+  - Le Song
+year: 2017
+date: 2017-04-05
+venue: NIPS
+paper_url: https://papers.nips.cc/paper_files/paper/2017/hash/d9896106ca98d3d05b8cbdf4fd8b13a1-Abstract.html
+arxiv_url: https://arxiv.org/abs/1704.01665
+code_url: https://github.com/Hanjun-Dai/graph_comb_opt
+institutions:
+  - Georgia Institute of Technology
+  - Ant Financial
+scope: specialist
+paradigm: constructive
+problem_families:
+  - Graph Optimization
+  - Routing
+problems:
+  - Minimum Vertex Cover
+  - Maximum Cut
+  - Traveling Salesman Problem
+summary: S2V-DQN combines graph embeddings and fitted Q-learning to learn greedy construction heuristics for graph combinatorial optimization problems.
+---
+
+# Learning Combinatorial Optimization Algorithms over Graphs
+
+> **TL;DR:** S2V-DQN learns greedy graph algorithms by using structure2vec embeddings inside a Q-learning policy that adds one node to the partial solution at a time.
+
+## Motivation
+
+Designing effective heuristics for NP-hard graph optimization problems usually requires problem-specific expertise and repeated experimentation. In many applications, similar instances of the same graph problem are solved repeatedly, making it useful to learn heuristics from an instance distribution. This paper asks whether graph structure and reinforcement learning can be combined to learn such heuristics automatically.
+
+## Contributions
+
+- Frames graph combinatorial optimization as learning a greedy meta-algorithm that constructs a solution by adding nodes sequentially.
+- Uses structure2vec graph embeddings to represent nodes in the context of both the graph and the current partial solution.
+- Trains the greedy policy with fitted Q-learning rather than whole-solution policy-gradient updates.
+- Applies the same high-level framework to Minimum Vertex Cover, Maximum Cut, and Traveling Salesman Problem.
+- Evaluates generalization to larger graphs and benchmark or real-world datasets.
+- Provides qualitative analysis of learned heuristics for MVC and MAXCUT.
+
+## Methodology
+
+1. A graph optimization problem is expressed through a common greedy construction template.
+2. The state consists of the graph and the current partial solution.
+3. Candidate actions correspond to adding a node to the partial solution.
+4. A helper procedure maps the ordered selected nodes to a feasible problem-specific structure.
+5. structure2vec computes node embeddings that reflect graph neighborhoods and the current partial solution.
+6. A Q-network scores candidate nodes by estimating the future objective contribution of each action.
+7. Fitted Q-learning trains the model from replayed transitions, and inference uses the learned greedy policy.
+
+## Experiments
+
+- **Problems:** Minimum Vertex Cover, Maximum Cut, and TSP in the main experiments; Set Covering Problem is included in the appendix.
+- **Synthetic data:** Erdos-Renyi and Barabasi-Albert graph families for MVC and MAXCUT, plus random and clustered Euclidean TSP instances.
+- **Benchmark and real-world data:** MemeTracker for MVC, physics MAXCUT instances, and TSPLIB for TSP.
+- **Baselines:** Pointer Network actor-critic, MVC approximation heuristics, MAXCUT approximation and SDP-based methods, CPLEX, Concorde, Christofides, insertion heuristics, nearest neighbor, MST, and 2-opt.
+- **Metrics:** Approximation ratio relative to optimal or best-known solutions, runtime, generalization across graph sizes, and benchmark performance.
+- **Main finding:** S2V-DQN performs strongly on MVC and MAXCUT, generalizes from smaller training graphs to larger test graphs, and outperforms the tested competitors on the reported realistic datasets; on synthetic TSP, classical heuristics such as farthest insertion and 2-opt remain competitive.
+
+## Limitations
+
+Author-reported constraints and curator observations are separated to keep interpretation transparent.
+
+### Reported by the Authors
+
+- For dense graphs, the authors identify edge sampling for graph embedding computation as future work to reduce runtime.
+- Some approximation ratios are computed against the best solution found by solvers within a one-hour cutoff, so the reference may not always be truly optimal.
+- Runtime comparisons are affected by hardware differences because the learned method uses GPU computation.
+
+### Curator Notes
+
+- The framework is evaluated by training problem-specific policies, so it does not meet this repository's definition of a generalist neural solver.
+- The greedy construction template is natural for the studied problems but may require nontrivial helper procedures for other combinatorial structures.
+- The main reported gains are strongest on graph-structured MVC and MAXCUT; TSP results are more mixed against strong classical heuristics.
+- Learned behavior is analyzed empirically, but the method does not provide approximation guarantees comparable to classical approximation algorithms.
+
+## Reproducibility
+
+- **Official implementation:** [Hanjun-Dai/graph_comb_opt](https://github.com/Hanjun-Dai/graph_comb_opt)
+- **Checkpoints:** Not clearly documented.
+- **Main paper references:** Sections 2-6 and Appendices B-D.

--- a/specialist/neural-combinatorial-optimization.md
+++ b/specialist/neural-combinatorial-optimization.md
@@ -1,0 +1,84 @@
+---
+id: neural-combinatorial-optimization
+short_title: NCO
+title: 'Neural Combinatorial Optimization with Reinforcement Learning'
+authors:
+  - Irwan Bello
+  - Hieu Pham
+  - Quoc V. Le
+  - Mohammad Norouzi
+  - Samy Bengio
+year: 2017
+date: 2016-11-29
+venue: ICLR
+paper_url: https://arxiv.org/abs/1611.09940
+arxiv_url: https://arxiv.org/abs/1611.09940
+institutions:
+  - Google Brain
+scope: specialist
+paradigm: constructive
+problem_families:
+  - Routing
+  - Packing
+problems:
+  - Traveling Salesman Problem
+  - Knapsack Problem
+summary: Neural Combinatorial Optimization trains a pointer-network policy with reinforcement learning to construct solutions for TSP and knapsack instances.
+---
+
+# Neural Combinatorial Optimization with Reinforcement Learning
+
+> **TL;DR:** Neural Combinatorial Optimization learns a pointer-network policy that constructs combinatorial solutions directly from reward feedback instead of supervised optimal labels.
+
+## Motivation
+
+Classical combinatorial optimization solvers often depend on hand-designed heuristics that work well for a specific problem but must be redesigned when the problem changes. Supervised neural approaches also require optimal or high-quality labels, which are expensive or unavailable for many NP-hard problems. This paper investigates whether neural networks can learn construction heuristics directly from solution-quality rewards.
+
+## Contributions
+
+- Introduces Neural Combinatorial Optimization, a reinforcement-learning framework for training neural policies over combinatorial solutions.
+- Uses a Pointer Network to represent a stochastic policy over permutations or subsets of input elements.
+- Trains the policy with policy gradients and an actor-critic baseline, using negative tour length or objective value as the reward.
+- Studies both RL pretraining across generated instances and active search on a single test instance.
+- Demonstrates the same framework on Euclidean TSP and 0-1 knapsack instances.
+
+## Methodology
+
+1. A combinatorial instance is encoded as a sequence of input elements, such as city coordinates for TSP or item weight-value pairs for knapsack.
+2. A Pointer Network encoder-decoder produces a distribution over the next element to select at each construction step.
+3. Feasibility is enforced when possible by masking invalid actions, such as already visited cities.
+4. A sampled solution receives a reward derived from the final objective value.
+5. Policy-gradient updates increase the probability of solutions with better rewards.
+6. In RL pretraining, the model is trained on generated instances and then decoded greedily or by sampling at test time.
+7. In active search, the policy is optimized on a single test instance while keeping the best sampled solution.
+
+## Experiments
+
+- **Problems:** Euclidean TSP with 20, 50, and 100 nodes; 0-1 knapsack with 50, 100, and 200 items.
+- **Data:** Randomly generated TSP points in the unit square and randomly generated knapsack item weights and values.
+- **Baselines:** Supervised Pointer Networks, Christofides heuristic, OR-Tools local search, Concorde, Lin-Kernighan-Helsgaun, random search, and greedy weight-to-value knapsack heuristic.
+- **Metrics:** Average tour length, running time, ratio to optimality, and knapsack objective value.
+- **Main finding:** Reinforcement learning improves over supervised Pointer Network training and produces close-to-optimal TSP tours up to 100 nodes when enough inference-time search is allowed; active search solves the tested knapsack instances to optimality in the reported experiments.
+
+## Limitations
+
+Author-reported constraints and curator observations are separated to keep interpretation transparent.
+
+### Reported by the Authors
+
+- The architecture must be adapted to the target combinatorial problem; for example, Pointer Networks naturally fit permutations, truncated permutations, or subsets.
+- Feasibility can be difficult for problems where invalid partial decisions are not easy to identify, such as TSP with time windows.
+- Penalty-based handling of constraints is proposed as future work and does not guarantee feasible samples at inference time.
+
+### Curator Notes
+
+- The strongest results rely on sampling or active search with large inference budgets, so comparisons should account for the number of candidate solutions and runtime.
+- The learned policy is not a shared cross-problem checkpoint; applying the framework to another problem still requires problem-specific modeling and training.
+- Main TSP experiments use synthetic Euclidean instances up to 100 nodes, so performance on larger or real-world routing data is not established by this paper.
+- The paper states that TensorFlow code would be released, but the PDF itself does not provide a stable official implementation link.
+
+## Reproducibility
+
+- **Official implementation:** Not publicly available in the paper.
+- **Checkpoints:** Not publicly available in the paper.
+- **Main paper references:** Sections 3-6 and Appendices A.1-A.4.

--- a/specialist/rl-vrp.md
+++ b/specialist/rl-vrp.md
@@ -1,0 +1,85 @@
+---
+id: rl-vrp
+short_title: RL-VRP
+title: 'Reinforcement Learning for Solving the Vehicle Routing Problem'
+authors:
+  - Mohammadreza Nazari
+  - Afshin Oroojlooy
+  - Martin Takac
+  - Lawrence V. Snyder
+year: 2018
+date: 2018-02-12
+venue: NeurIPS
+paper_url: https://papers.nips.cc/paper_files/paper/2018/hash/9fb4651c05b2ed70fba5afe0b039a550-Abstract.html
+arxiv_url: https://arxiv.org/abs/1802.04240
+code_url: https://github.com/OptMLGroup/VRP-RL
+institutions:
+  - Lehigh University
+scope: specialist
+paradigm: constructive
+problem_families:
+  - Routing
+problems:
+  - Vehicle Routing Problem
+  - Capacitated Vehicle Routing Problem
+summary: RL-VRP trains an attention-based reinforcement-learning policy to construct capacitated vehicle routes while updating dynamic demand and capacity states.
+---
+
+# Reinforcement Learning for Solving the Vehicle Routing Problem
+
+> **TL;DR:** RL-VRP learns a constructive policy that routes a capacitated vehicle by selecting the next customer from feasible actions at each decoding step.
+
+## Motivation
+
+Vehicle Routing Problem variants are difficult to solve exactly and often rely on specialized heuristics. Earlier neural combinatorial optimization methods based on Pointer Networks were designed for static inputs such as TSP tours, but VRP has dynamic state: customer demand and remaining vehicle load change as a route is constructed. This paper adapts reinforcement-learning-based neural construction to capacitated VRP.
+
+## Contributions
+
+- Proposes an end-to-end reinforcement-learning framework for capacitated VRP instances sampled from a fixed distribution.
+- Separates static elements, such as locations, from dynamic elements, such as remaining demand and vehicle load.
+- Removes the recurrent encoder used in Pointer Networks and uses embeddings plus an RNN decoder with attention over feasible destinations.
+- Uses masking to enforce VRP feasibility rules during decoding.
+- Evaluates greedy and beam-search decoding against classical VRP heuristics and Google OR-Tools.
+- Shows that the same trained model can support split delivery behavior by modifying the masking scheme without retraining.
+
+## Methodology
+
+1. A VRP instance is represented by depot and customer locations, customer demands, and vehicle capacity.
+2. Static location features and dynamic demand/load features are embedded separately.
+3. An RNN decoder keeps track of the partial route sequence.
+4. At each decision step, an attention mechanism scores feasible next destinations.
+5. A mask removes invalid actions, such as visiting fully served customers or selecting a customer whose demand exceeds remaining capacity.
+6. The route is decoded greedily or with beam search until all demand is served.
+7. The policy is trained with REINFORCE and a critic baseline to minimize expected route length.
+
+## Experiments
+
+- **Problems:** Capacitated VRP with 10, 20, 50, and 100 customers; split-delivery VRP variants; a stochastic VRP example in the appendix.
+- **Data:** Randomly generated customer locations and demands with fixed capacity settings for each problem size.
+- **Baselines:** Clarke-Wright savings heuristic, Sweep heuristic, randomized versions of both heuristics, Google OR-Tools, and exact mixed-integer solutions for small instances.
+- **Metrics:** Average tour length, standard deviation, solution time, optimality gap for small instances, and pairwise winning rate for larger instances.
+- **Main finding:** Beam-search decoding improves solution quality over greedy decoding; on medium-sized instances the learned policy outperforms the tested classical heuristics and is competitive with or better than OR-Tools under the paper's evaluation setup.
+
+## Limitations
+
+Author-reported constraints and curator observations are separated to keep interpretation transparent.
+
+### Reported by the Authors
+
+- The trained policy is expected to work on instances drawn from the same distribution used in training.
+- Hard constraints such as time windows can require problem-specific masking, which the authors note may itself be challenging.
+- Extending the framework to other combinatorial optimization problems, such as bin packing, job shop scheduling, and flow shop scheduling, is identified as future work.
+- Runtime comparisons with OR-Tools are not exact because OR-Tools is implemented in C++ while the reported learning baselines use Python.
+
+### Curator Notes
+
+- The method is specialist under this repository's taxonomy because training is tied to a VRP distribution and problem setting.
+- Results are mainly on synthetic random VRP instances rather than operational logistics benchmarks.
+- Beam search improves quality but changes the inference budget, so greedy and beam-search results should be compared with runtime in mind.
+- The split-delivery result comes from modifying feasibility masking rather than retraining a solver specifically for the relaxed problem.
+
+## Reproducibility
+
+- **Official implementation:** [OptMLGroup/VRP-RL](https://github.com/OptMLGroup/VRP-RL)
+- **Checkpoints:** Not clearly documented.
+- **Main paper references:** Sections 3-5 and Appendices A-C.


### PR DESCRIPTION
本 PR 新增了三篇经典 Neural Combinatorial Optimization 论文，并按照仓库现有格式整理为 specialist solver notes：

- Neural Combinatorial Optimization with Reinforcement Learning
- Reinforcement Learning for Solving the Vehicle Routing Problem
- Learning Combinatorial Optimization Algorithms over Graphs

每篇 note 都包含结构化 Front Matter，并按模板补充了以下部分：

- Motivation
- Contributions
- Methodology
- Experiments
- Limitations
- Reproducibility

同时已更新 `specialist/README.md` 中的自动生成论文索引。