### PR TITLE
Use acceptance dates for timelines and expand paper relations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Required fields:
 - **`title`:** Full paper title.
 - **`authors`:** One author per YAML list item, in paper order.
 - **`year`:** Conference or journal year.
-- **`date`:** First public release date in `YYYY-MM-DD` format, normally the arXiv v1 date.
+- **`date`:** First public release date in `YYYY-MM-DD` format. When `arxiv_url` is present, use the arXiv v1 date.
 - **`venue`:** Conference, journal, or `arXiv`.
 - **`paper_url`:** Original paper page or public PDF.
 - **`institutions`:** Human-readable institution names.
@@ -46,6 +46,14 @@ Optional fields:
   - **`source_url`:** Public URL for the original paper or PDF containing the figure.
 
 Framework images must be cropped from a publicly available original paper, not generated or redrawn. Crop the figure body without the printed caption, keep labels legible, and use a PNG around 1600–2000 px wide. If no reliable original image is publicly available, omit `figure` entirely.
+
+Formally accepted papers must also declare an **`acceptance`** block. Its `date` may use `YYYY`, `YYYY-MM`, or `YYYY-MM-DD`; record only the precision supported by an official decision record, publisher history, or conference notification page. `source_url` must link to that evidence. Do not infer a decision month from the proceedings date or venue year. Papers whose venue is `arXiv` must omit this block.
+
+```yaml
+acceptance:
+  date: '2025-01-22'
+  source_url: https://iclr.cc/Conferences/2025/Dates
+```
 
 ## Paper Relations
 

--- a/data/relations.yml
+++ b/data/relations.yml
@@ -464,3 +464,315 @@ relations:
   - papers: [drhg, nds]
     kind: search
     description: Both learn large-neighborhood destruction while delegating reconstruction to a repair stage, using hypergraph groups and neural deconstruction.
+  - papers: [bq-nco, reld]
+    kind: architecture
+    description: "BQ-NCO and ReLD both reorganize routing context, decoder capacity, or candidate access to transfer a constructive policy beyond its training scale."
+  - papers: [lehd, pointerformer]
+    kind: architecture
+    description: "LEHD and Pointerformer both reorganize routing context, decoder capacity, or candidate access to transfer a constructive policy beyond its training scale."
+  - papers: [invit, fer]
+    kind: architecture
+    description: "INViT and FER both reorganize routing context, decoder capacity, or candidate access to transfer a constructive policy beyond its training scale."
+  - papers: [dar, icam]
+    kind: architecture
+    description: "DAR and ICAM both reorganize routing context, decoder capacity, or candidate access to transfer a constructive policy beyond its training scale."
+  - papers: [elg, sil]
+    kind: architecture
+    description: "ELG and SIL both reorganize routing context, decoder capacity, or candidate access to transfer a constructive policy beyond its training scale."
+  - papers: [less-is-more, softdist]
+    kind: architecture
+    description: "Less Is More and SoftDist both encode geometric locality or invariance explicitly instead of relying only on dense absolute-coordinate attention."
+  - papers: [h-tsp, udc]
+    kind: search
+    description: "H-TSP and UDC both reduce a large routing decision to learned subproblems or route regions before assembling or improving the global solution."
+  - papers: [tam, glop]
+    kind: search
+    description: "TAM and GLOP both reduce a large routing decision to learned subproblems or route regions before assembling or improving the global solution."
+  - papers: [dpn, select-and-optimize]
+    kind: search
+    description: "DPN and Select & Optimize both reduce a large routing decision to learned subproblems or route regions before assembling or improving the global solution."
+  - papers: [hncs, l2seg]
+    kind: search
+    description: "HNCS and L2Seg both reduce a large routing decision to learned subproblems or route regions before assembling or improving the global solution."
+  - papers: [l2c-insert, dgl]
+    kind: search
+    description: "L2C-Insert and DGL both reduce a large routing decision to learned subproblems or route regions before assembling or improving the global solution."
+  - papers: [difusco, fast-t2t]
+    kind: search
+    description: "DIFUSCO and Fast T2T both optimize a continuous or probabilistic solution representation and require a decoding or search stage to recover discrete tours."
+  - papers: [t2t, gensco]
+    kind: search
+    description: "T2T and GenSCO both optimize a continuous or probabilistic solution representation and require a decoding or search stage to recover discrete tours."
+  - papers: [utsp, gfacs]
+    kind: search
+    description: "UTSP and GFACS both optimize a continuous or probabilistic solution representation and require a decoding or search stage to recover discrete tours."
+  - papers: [nds, omni-vrp]
+    kind: search
+    description: "NDS and Omni-VRP both improve routing solutions by selecting a structured region to remove or revisit and then reconstructing that region with a separate repair mechanism."
+  - papers: [mtpomo, cada]
+    kind: scope
+    description: "MTPOMO and CaDA both share substantial routing representations across multiple VRP variants but use different task attributes, experts, adapters, or geometries for specialization."
+  - papers: [mvmoe, cross-problem-learning]
+    kind: scope
+    description: "MVMoE and Cross-Problem Learning both share substantial routing representations across multiple VRP variants but use different task attributes, experts, adapters, or geometries for specialization."
+  - papers: [mtl-kd, routefinder]
+    kind: scope
+    description: "MTL-KD and RouteFinder both share substantial routing representations across multiple VRP variants but use different task attributes, experts, adapters, or geometries for specialization."
+  - papers: [urs, shield]
+    kind: scope
+    description: "URS and SHIELD both share substantial routing representations across multiple VRP variants but use different task attributes, experts, adapters, or geometries for specialization."
+  - papers: [polynet, gumbeldore]
+    kind: learning
+    description: "PolyNet and Gumbeldore both maintain multiple construction trajectories or policies so inference explores complementary high-quality solutions."
+  - papers: [compass, agfn]
+    kind: learning
+    description: "COMPASS and AGFN both maintain multiple construction trajectories or policies so inference explores complementary high-quality solutions."
+  - papers: [meta-sage, asp]
+    kind: learning
+    description: "Meta-SAGE and ASP both adapt a pretrained solver, latent state, or generated search distribution for an individual test instance instead of using only a frozen greedy policy."
+  - papers: [pointer-networks, learning-heuristic]
+    kind: architecture
+    description: "Ptr-Net and Learning Heuristic both use autoregressive selection over input items, with different encoders or state-update rules supplying the context for the next pointer decision."
+  - papers: [ttpl, mixed-curvature]
+    kind: learning
+    description: "TTPL and Mixed-Curvature both target routing distribution or size shift through explicit robustness, adaptation, normalization, or representation design."
+  - papers: [bq-nco, l2r]
+    kind: architecture
+    description: "BQ-NCO and L2R both reorganize routing context, decoder capacity, or candidate access to transfer a constructive policy beyond its training scale."
+  - papers: [drhg, l2seg]
+    kind: search
+    description: "DRHG and L2Seg both improve routing solutions by selecting a structured region to remove or revisit and then reconstructing that region with a separate repair mechanism."
+  - papers: [neuopt, neural-3-opt]
+    kind: search
+    description: "NeuOpt and Neural-3-OPT both learn where or how to apply local route modifications while retaining an iterative incumbent-based improvement loop."
+  - papers: [ncs, neurewriter]
+    kind: search
+    description: "NCS and NeuRewriter both learn where or how to apply local route modifications while retaining an iterative incumbent-based improvement loop."
+  - papers: [pip, cada]
+    kind: learning
+    description: "PIP/PIP-D and CaDA both expose constraint structure to the learned policy so feasibility or task identity influences decisions before a complete route is produced."
+  - papers: [constraint-tightness, urs]
+    kind: learning
+    description: "Constraint Tightness and URS both expose constraint structure to the learned policy so feasibility or task identity influences decisions before a complete route is produced."
+  - papers: [lehd, reld]
+    kind: architecture
+    description: "LEHD and ReLD both reorganize routing context, decoder capacity, or candidate access to transfer a constructive policy beyond its training scale."
+  - papers: [pointerformer, invit]
+    kind: architecture
+    description: "Pointerformer and INViT both reorganize routing context, decoder capacity, or candidate access to transfer a constructive policy beyond its training scale."
+  - papers: [dar, fer]
+    kind: architecture
+    description: "DAR and FER both reorganize routing context, decoder capacity, or candidate access to transfer a constructive policy beyond its training scale."
+  - papers: [icam, elg]
+    kind: architecture
+    description: "ICAM and ELG both reorganize routing context, decoder capacity, or candidate access to transfer a constructive policy beyond its training scale."
+  - papers: [l2r, sil]
+    kind: architecture
+    description: "L2R and SIL both reorganize routing context, decoder capacity, or candidate access to transfer a constructive policy beyond its training scale."
+  - papers: [utsp, softdist]
+    kind: architecture
+    description: "UTSP and SoftDist both encode geometric locality or invariance explicitly instead of relying only on dense absolute-coordinate attention."
+  - papers: [h-tsp, glop]
+    kind: search
+    description: "H-TSP and GLOP both reduce a large routing decision to learned subproblems or route regions before assembling or improving the global solution."
+  - papers: [tam, udc]
+    kind: search
+    description: "TAM and UDC both reduce a large routing decision to learned subproblems or route regions before assembling or improving the global solution."
+  - papers: [dpn, l2c-insert]
+    kind: search
+    description: "DPN and L2C-Insert both reduce a large routing decision to learned subproblems or route regions before assembling or improving the global solution."
+  - papers: [hncs, select-and-optimize]
+    kind: search
+    description: "HNCS and Select & Optimize both reduce a large routing decision to learned subproblems or route regions before assembling or improving the global solution."
+  - papers: [difusco, gensco]
+    kind: search
+    description: "DIFUSCO and GenSCO both optimize a continuous or probabilistic solution representation and require a decoding or search stage to recover discrete tours."
+  - papers: [t2t, fast-t2t]
+    kind: search
+    description: "T2T and Fast T2T both optimize a continuous or probabilistic solution representation and require a decoding or search stage to recover discrete tours."
+  - papers: [gnn-mcts-tsp, gfacs]
+    kind: search
+    description: "GNN-MCTS and GFACS both learn edge-level guidance that narrows or prioritizes a downstream combinatorial search rather than treating raw network scores as the final tour."
+  - papers: [nds, learning-to-improve]
+    kind: search
+    description: "NDS and L2I both improve routing solutions by selecting a structured region to remove or revisit and then reconstructing that region with a separate repair mechanism."
+  - papers: [drhg, egate]
+    kind: search
+    description: "DRHG and EGATE both improve routing solutions by selecting a structured region to remove or revisit and then reconstructing that region with a separate repair mechanism."
+  - papers: [learning-collaborative-policies, omni-vrp]
+    kind: search
+    description: "LCP and Omni-VRP both improve routing solutions by selecting a structured region to remove or revisit and then reconstructing that region with a separate repair mechanism."
+  - papers: [mtpomo, cross-problem-learning]
+    kind: scope
+    description: "MTPOMO and Cross-Problem Learning both share substantial routing representations across multiple VRP variants but use different task attributes, experts, adapters, or geometries for specialization."
+  - papers: [mvmoe, mtl-kd]
+    kind: scope
+    description: "MVMoE and MTL-KD both share substantial routing representations across multiple VRP variants but use different task attributes, experts, adapters, or geometries for specialization."
+  - papers: [routefinder, shield]
+    kind: scope
+    description: "RouteFinder and SHIELD both share substantial routing representations across multiple VRP variants but use different task attributes, experts, adapters, or geometries for specialization."
+  - papers: [multi-decoder-attention-model, polynet]
+    kind: learning
+    description: "MDAM and PolyNet both maintain multiple construction trajectories or policies so inference explores complementary high-quality solutions."
+  - papers: [compass, gumbeldore]
+    kind: learning
+    description: "COMPASS and Gumbeldore both maintain multiple construction trajectories or policies so inference explores complementary high-quality solutions."
+  - papers: [agfn, simulation-guided-beam-search]
+    kind: learning
+    description: "AGFN and SGBS both maintain multiple construction trajectories or policies so inference explores complementary high-quality solutions."
+  - papers: [meta-sage, latent-search-space-routing]
+    kind: learning
+    description: "Meta-SAGE and CVAE-Opt both adapt a pretrained solver, latent state, or generated search distribution for an individual test instance instead of using only a frozen greedy policy."
+  - papers: [ttpl, asp]
+    kind: learning
+    description: "TTPL and ASP both adapt a pretrained solver, latent state, or generated search distribution for an individual test instance instead of using only a frozen greedy policy."
+  - papers: [pointer-networks, matrix-encoding-networks]
+    kind: architecture
+    description: "Ptr-Net and MatNet both use autoregressive selection over input items, with different encoders or state-update rules supplying the context for the next pointer decision."
+  - papers: [learning-heuristic, step-wise-routing]
+    kind: architecture
+    description: "Learning Heuristic and Step-Wise both use autoregressive selection over input items, with different encoders or state-update rules supplying the context for the next pointer decision."
+  - papers: [routing-dro, mixed-curvature]
+    kind: learning
+    description: "DRO and Mixed-Curvature both target routing distribution or size shift through explicit robustness, adaptation, normalization, or representation design."
+  - papers: [pareto-set-learning, constraint-tightness]
+    kind: learning
+    description: "P-MOCO and Constraint Tightness both condition a learned solver on objectives or operating constraints that change which routing solution is preferred."
+  - papers: [invit, less-is-more]
+    kind: architecture
+    description: "INViT and Less Is More both encode geometric locality or invariance explicitly instead of relying only on dense absolute-coordinate attention."
+  - papers: [h-tsp, dgl]
+    kind: search
+    description: "H-TSP and DGL both reduce a large routing decision to learned subproblems or route regions before assembling or improving the global solution."
+  - papers: [learning-improvement-heuristics, neuopt]
+    kind: search
+    description: "LIH and NeuOpt both learn where or how to apply local route modifications while retaining an iterative incumbent-based improvement loop."
+  - papers: [ncs, neural-3-opt]
+    kind: search
+    description: "NCS and Neural-3-OPT both learn where or how to apply local route modifications while retaining an iterative incumbent-based improvement loop."
+  - papers: [pip, urs]
+    kind: learning
+    description: "PIP/PIP-D and URS both expose constraint structure to the learned policy so feasibility or task identity influences decisions before a complete route is produced."
+  - papers: [pointer-networks, dynamic-am]
+    kind: architecture
+    description: "Ptr-Net and AM-D both use autoregressive selection over input items, with different encoders or state-update rules supplying the context for the next pointer decision."
+  - papers: [bq-nco, pointerformer]
+    kind: architecture
+    description: "BQ-NCO and Pointerformer both reorganize routing context, decoder capacity, or candidate access to transfer a constructive policy beyond its training scale."
+  - papers: [lehd, dar]
+    kind: architecture
+    description: "LEHD and DAR both reorganize routing context, decoder capacity, or candidate access to transfer a constructive policy beyond its training scale."
+  - papers: [reld, fer]
+    kind: architecture
+    description: "ReLD and FER both reorganize routing context, decoder capacity, or candidate access to transfer a constructive policy beyond its training scale."
+  - papers: [icam, l2r]
+    kind: architecture
+    description: "ICAM and L2R both reorganize routing context, decoder capacity, or candidate access to transfer a constructive policy beyond its training scale."
+  - papers: [elg, less-is-more]
+    kind: architecture
+    description: "ELG and Less Is More both encode geometric locality or invariance explicitly instead of relying only on dense absolute-coordinate attention."
+  - papers: [tam, dpn]
+    kind: search
+    description: "TAM and DPN both reduce a large routing decision to learned subproblems or route regions before assembling or improving the global solution."
+  - papers: [udc, hncs]
+    kind: search
+    description: "UDC and HNCS both reduce a large routing decision to learned subproblems or route regions before assembling or improving the global solution."
+  - papers: [glop, select-and-optimize]
+    kind: search
+    description: "GLOP and Select & Optimize both reduce a large routing decision to learned subproblems or route regions before assembling or improving the global solution."
+  - papers: [l2seg, l2c-insert]
+    kind: search
+    description: "L2Seg and L2C-Insert both reduce a large routing decision to learned subproblems or route regions before assembling or improving the global solution."
+  - papers: [dgl, rbg]
+    kind: search
+    description: "DGL and RBG both reduce a large routing decision to learned subproblems or route regions before assembling or improving the global solution."
+  - papers: [difusco, softdist]
+    kind: search
+    description: "DIFUSCO and SoftDist both optimize a continuous or probabilistic solution representation and require a decoding or search stage to recover discrete tours."
+  - papers: [t2t, utsp]
+    kind: search
+    description: "T2T and UTSP both optimize a continuous or probabilistic solution representation and require a decoding or search stage to recover discrete tours."
+  - papers: [fast-t2t, dimes]
+    kind: search
+    description: "Fast T2T and DIMES both optimize a continuous or probabilistic solution representation and require a decoding or search stage to recover discrete tours."
+  - papers: [gensco, gfacs]
+    kind: search
+    description: "GenSCO and GFACS both optimize a continuous or probabilistic solution representation and require a decoding or search stage to recover discrete tours."
+  - papers: [gnn-mcts-tsp, neurolkh]
+    kind: search
+    description: "GNN-MCTS and NeuroLKH both learn edge-level guidance that narrows or prioritizes a downstream combinatorial search rather than treating raw network scores as the final tour."
+  - papers: [att-gcn, deep-policy-dynamic-programming]
+    kind: search
+    description: "Att-GCN and DPDP both learn edge-level guidance that narrows or prioritizes a downstream combinatorial search rather than treating raw network scores as the final tour."
+  - papers: [nds, egate]
+    kind: search
+    description: "NDS and EGATE both improve routing solutions by selecting a structured region to remove or revisit and then reconstructing that region with a separate repair mechanism."
+  - papers: [drhg, learning-to-improve]
+    kind: search
+    description: "DRHG and L2I both improve routing solutions by selecting a structured region to remove or revisit and then reconstructing that region with a separate repair mechanism."
+  - papers: [neuopt, neurewriter]
+    kind: search
+    description: "NeuOpt and NeuRewriter both learn where or how to apply local route modifications while retaining an iterative incumbent-based improvement loop."
+  - papers: [mtpomo, mtl-kd]
+    kind: scope
+    description: "MTPOMO and MTL-KD both share substantial routing representations across multiple VRP variants but use different task attributes, experts, adapters, or geometries for specialization."
+  - papers: [mvmoe, cada]
+    kind: scope
+    description: "MVMoE and CaDA both share substantial routing representations across multiple VRP variants but use different task attributes, experts, adapters, or geometries for specialization."
+  - papers: [cross-problem-learning, routefinder]
+    kind: scope
+    description: "Cross-Problem Learning and RouteFinder both share substantial routing representations across multiple VRP variants but use different task attributes, experts, adapters, or geometries for specialization."
+  - papers: [omni-vrp, shield]
+    kind: scope
+    description: "Omni-VRP and SHIELD both share substantial routing representations across multiple VRP variants but use different task attributes, experts, adapters, or geometries for specialization."
+  - papers: [pip, mapdp]
+    kind: learning
+    description: "PIP/PIP-D and MAPDP both expose constraint structure to the learned policy so feasibility or task identity influences decisions before a complete route is produced."
+  - papers: [multi-decoder-attention-model, compass]
+    kind: learning
+    description: "MDAM and COMPASS both maintain multiple construction trajectories or policies so inference explores complementary high-quality solutions."
+  - papers: [polynet, agfn]
+    kind: learning
+    description: "PolyNet and AGFN both maintain multiple construction trajectories or policies so inference explores complementary high-quality solutions."
+  - papers: [gumbeldore, simulation-guided-beam-search]
+    kind: learning
+    description: "Gumbeldore and SGBS both maintain multiple construction trajectories or policies so inference explores complementary high-quality solutions."
+  - papers: [meta-sage, sil]
+    kind: learning
+    description: "Meta-SAGE and SIL both adapt a pretrained solver, latent state, or generated search distribution for an individual test instance instead of using only a frozen greedy policy."
+  - papers: [ttpl, latent-search-space-routing]
+    kind: learning
+    description: "TTPL and CVAE-Opt both adapt a pretrained solver, latent state, or generated search distribution for an individual test instance instead of using only a frozen greedy policy."
+  - papers: [rl-vrp, learning-heuristic]
+    kind: architecture
+    description: "VRP-RL and Learning Heuristic both use autoregressive selection over input items, with different encoders or state-update rules supplying the context for the next pointer decision."
+  - papers: [matrix-encoding-networks, step-wise-routing]
+    kind: architecture
+    description: "MatNet and Step-Wise both use autoregressive selection over input items, with different encoders or state-update rules supplying the context for the next pointer decision."
+  - papers: [learning-co-over-graphs, routing-dro]
+    kind: learning
+    description: "S2V-DQN and DRO both combine graph-structured representations with reinforcement-learning signals to guide sequential combinatorial decisions."
+  - papers: [asp, mixed-curvature]
+    kind: learning
+    description: "ASP and Mixed-Curvature both target routing distribution or size shift through explicit robustness, adaptation, normalization, or representation design."
+  - papers: [neural-large-neighborhood-search, learning-collaborative-policies]
+    kind: search
+    description: "NLNS and LCP both improve routing solutions by selecting a structured region to remove or revisit and then reconstructing that region with a separate repair mechanism."
+  - papers: [learning-improvement-heuristics, ncs]
+    kind: search
+    description: "LIH and NCS both learn where or how to apply local route modifications while retaining an iterative incumbent-based improvement loop."
+  - papers: [constraint-tightness, cada]
+    kind: learning
+    description: "Constraint Tightness and CaDA both expose constraint structure to the learned policy so feasibility or task identity influences decisions before a complete route is produced."
+  - papers: [multi-decoder-attention-model, sym-nco]
+    kind: learning
+    description: "MDAM and Sym-NCO both maintain multiple construction trajectories or policies so inference explores complementary high-quality solutions."
+  - papers: [polynet, pareto-set-learning]
+    kind: learning
+    description: "PolyNet and P-MOCO both maintain multiple construction trajectories or policies so inference explores complementary high-quality solutions."
+  - papers: [rl-vrp, dynamic-am]
+    kind: architecture
+    description: "VRP-RL and AM-D both use autoregressive selection over input items, with different encoders or state-update rules supplying the context for the next pointer decision."
+  - papers: [learning-co-over-graphs, practical-vrp-joint-learning]
+    kind: learning
+    description: "S2V-DQN and GCN-NPEC both combine graph-structured representations with reinforcement-learning signals to guide sequential combinatorial decisions."

--- a/docs/PAPER_TEMPLATE.md
+++ b/docs/PAPER_TEMPLATE.md
@@ -12,6 +12,10 @@ authors:
   - Second Author
 year: 2025
 date: 2024-01-01
+acceptance:
+  # Use only the precision supported by the linked official source: YYYY, YYYY-MM, or YYYY-MM-DD.
+  date: '2025-01-22'
+  source_url: https://example-conference.org/official-dates
 venue: Conference or Journal
 paper_url: https://example.com/paper.pdf
 # arxiv_url: https://arxiv.org/abs/0000.00000
@@ -71,5 +75,7 @@ Explain the research problem, prior limitation, and why the proposed direction m
 - **Checkpoints:** Availability.
 - **Main paper references:** Relevant sections, tables, figures, or appendices.
 ```
+
+For an arXiv-only paper, set `venue: arXiv` and remove the `acceptance` block. When `arxiv_url` is present, `date` must represent the arXiv v1 date.
 
 If a public original framework image is available, crop only the figure body into `public/paper-assets/paper-id/framework.png`; otherwise leave the entire `figure` block commented out. Add at least one undirected thematic connection for the new paper in `data/relations.yml`.

--- a/generalist/README.md
+++ b/generalist/README.md
@@ -32,17 +32,9 @@ Select a paper title to open its research note.
 - **Problems:** Capacitated Vehicle Routing Problem; Vehicle Routing Problem with Time Windows; Pickup and Delivery Vehicle Routing Problem
 - **Venue:** ICML
 - **Year:** 2026
-- **First public:** 2025-09-27
+- **Accepted:** [2026-04-30](https://icml.cc/Conferences/2026/Dates)
+- **arXiv:** [2025-09-27](https://arxiv.org/abs/2509.23413)
 - **Institutions:** Southern University of Science and Technology
-
-### [SHIELD: Multi-task Multi-distribution Vehicle Routing Solver with Sparsity and Hierarchy](shield.md)
-
-- **Paradigm:** Constructive
-- **Problems:** Capacitated Vehicle Routing Problem; Open Vehicle Routing Problem; Vehicle Routing Problem with Time Windows
-- **Venue:** ICML
-- **Year:** 2025
-- **First public:** 2025-06-10
-- **Institutions:** National University of Singapore
 
 ### [MTL-KD: Multi-Task Learning Via Knowledge Distillation for Generalizable Neural Vehicle Routing Solver](mtl-kd.md)
 
@@ -50,8 +42,29 @@ Select a paper title to open its research note.
 - **Problems:** Capacitated Vehicle Routing Problem; Open Vehicle Routing Problem; Pickup and Delivery Vehicle Routing Problem
 - **Venue:** NeurIPS
 - **Year:** 2025
-- **First public:** 2025-06-03
+- **Accepted:** [2025-09-18](https://neurips.cc/Conferences/2025/CallForPapers)
+- **arXiv:** [2025-06-03](https://arxiv.org/abs/2506.02935)
 - **Institutions:** Southern University of Science and Technology
+
+### [RouteFinder: Towards Foundation Models for Vehicle Routing Problems](routefinder.md)
+
+- **Paradigm:** Constructive
+- **Problems:** Capacitated Vehicle Routing Problem; Open Vehicle Routing Problem; Vehicle Routing Problem with Time Windows; Pickup and Delivery Vehicle Routing Problem
+- **Venue:** TMLR
+- **Year:** 2025
+- **Accepted:** [2025-08](https://openreview.net/forum?id=QzGLoaOPiY)
+- **arXiv:** [2024-06-21](https://arxiv.org/abs/2406.15007)
+- **Institutions:** TU Dortmund University; KAIST
+
+### [SHIELD: Multi-task Multi-distribution Vehicle Routing Solver with Sparsity and Hierarchy](shield.md)
+
+- **Paradigm:** Constructive
+- **Problems:** Capacitated Vehicle Routing Problem; Open Vehicle Routing Problem; Vehicle Routing Problem with Time Windows
+- **Venue:** ICML
+- **Year:** 2025
+- **Accepted:** [2025-05-01](https://icml.cc/Conferences/2025/Dates)
+- **arXiv:** [2025-06-10](https://arxiv.org/abs/2506.08424)
+- **Institutions:** National University of Singapore
 
 ### [A Mixed-Curvature based Pre-training Paradigm for Multi-Task Vehicle Routing Solver](mixed-curvature.md)
 
@@ -59,7 +72,8 @@ Select a paper title to open its research note.
 - **Problems:** Capacitated Vehicle Routing Problem; Open Vehicle Routing Problem; Vehicle Routing Problem with Backhauls
 - **Venue:** ICML
 - **Year:** 2025
-- **First public:** 2025-01-28
+- **Accepted:** [2025-05-01](https://icml.cc/Conferences/2025/Dates)
+- **arXiv:** —
 - **Institutions:** Nanyang Technological University
 
 ### [CaDA: Cross-Problem Routing Solver with Constraint-Aware Dual-Attention](cada.md)
@@ -68,7 +82,8 @@ Select a paper title to open its research note.
 - **Problems:** Capacitated Vehicle Routing Problem; Open Vehicle Routing Problem; Vehicle Routing Problem with Backhauls; Pickup and Delivery Vehicle Routing Problem
 - **Venue:** ICML
 - **Year:** 2025
-- **First public:** 2024-11-30
+- **Accepted:** [2025-05-01](https://icml.cc/Conferences/2025/Dates)
+- **arXiv:** [2024-11-30](https://arxiv.org/abs/2412.00346)
 - **Institutions:** Southern University of Science and Technology
 
 ### [GOAL: A Generalist Combinatorial Optimization Agent Learner](goal.md)
@@ -77,17 +92,19 @@ Select a paper title to open its research note.
 - **Problems:** Asymmetric Traveling Salesman Problem; Capacitated Vehicle Routing Problem; Capacitated Vehicle Routing Problem with Time Windows; Orienteering Problem; Job Shop Scheduling Problem; Uniform Machine Scheduling Problem; Knapsack Problem; Minimum Vertex Cover
 - **Venue:** ICLR
 - **Year:** 2025
-- **First public:** 2024-06-21
+- **Accepted:** [2025-01-22](https://iclr.cc/Conferences/2025/Dates)
+- **arXiv:** [2024-06-21](https://arxiv.org/abs/2406.15079)
 - **Institutions:** NAVER LABS Europe
 
-### [RouteFinder: Towards Foundation Models for Vehicle Routing Problems](routefinder.md)
+### [Multi-Task Learning for Routing Problem with Cross-Problem Zero-Shot Generalization](mtpomo.md)
 
 - **Paradigm:** Constructive
-- **Problems:** Capacitated Vehicle Routing Problem; Open Vehicle Routing Problem; Vehicle Routing Problem with Time Windows; Pickup and Delivery Vehicle Routing Problem
-- **Venue:** TMLR
-- **Year:** 2025
-- **First public:** 2024-06-21
-- **Institutions:** TU Dortmund University; KAIST
+- **Problems:** Capacitated Vehicle Routing Problem; Open Vehicle Routing Problem; Vehicle Routing Problem with Backhauls; Pickup and Delivery Vehicle Routing Problem
+- **Venue:** KDD
+- **Year:** 2024
+- **Accepted:** [2024-05-16](https://www.kdd.org/kdd2024/research-track-call-for-papers/)
+- **arXiv:** [2024-02-23](https://arxiv.org/abs/2402.16891)
+- **Institutions:** Southern University of Science and Technology
 
 ### [MVMoE: Multi-Task Vehicle Routing Solver with Mixture-of-Experts](mvmoe.md)
 
@@ -95,7 +112,8 @@ Select a paper title to open its research note.
 - **Problems:** Capacitated Vehicle Routing Problem; Open Vehicle Routing Problem; Vehicle Routing Problem with Backhauls; Pickup and Delivery Vehicle Routing Problem
 - **Venue:** ICML
 - **Year:** 2024
-- **First public:** 2024-05-02
+- **Accepted:** [2024-05-01](https://icml.cc/Conferences/2024/Dates)
+- **arXiv:** [2024-05-02](https://arxiv.org/abs/2405.01029)
 - **Institutions:** Nanyang Technological University
 
 ### [Cross-Problem Learning for Solving Vehicle Routing Problems](cross-problem-learning.md)
@@ -104,17 +122,9 @@ Select a paper title to open its research note.
 - **Problems:** Capacitated Vehicle Routing Problem; Vehicle Routing Problem with Time Windows; Orienteering Problem
 - **Venue:** IJCAI
 - **Year:** 2024
-- **First public:** 2024-04-17
+- **Accepted:** [2024-04-16](https://ijcai24.org/call-for-papers/index.html)
+- **arXiv:** [2024-04-17](https://arxiv.org/abs/2404.11677)
 - **Institutions:** Nanyang Technological University
-
-### [Multi-Task Learning for Routing Problem with Cross-Problem Zero-Shot Generalization](mtpomo.md)
-
-- **Paradigm:** Constructive
-- **Problems:** Capacitated Vehicle Routing Problem; Open Vehicle Routing Problem; Vehicle Routing Problem with Backhauls; Pickup and Delivery Vehicle Routing Problem
-- **Venue:** KDD
-- **Year:** 2024
-- **First public:** 2024-02-23
-- **Institutions:** Southern University of Science and Technology
 <!-- GENERATED_PAPER_INDEX_END -->
 
 ## Adding a Generalist Solver

--- a/generalist/cada.md
+++ b/generalist/cada.md
@@ -10,6 +10,9 @@ authors:
   - "Zhenkun Wang"
 year: 2025
 date: 2024-11-30
+acceptance:
+  date: "2025-05-01"
+  source_url: "https://icml.cc/Conferences/2025/Dates"
 venue: "ICML"
 paper_url: "https://proceedings.mlr.press/v267/li25bi.html"
 arxiv_url: "https://arxiv.org/abs/2412.00346"

--- a/generalist/cross-problem-learning.md
+++ b/generalist/cross-problem-learning.md
@@ -12,6 +12,9 @@ authors:
   - "Senthilnath Jayavelu"
 year: 2024
 date: 2024-04-17
+acceptance:
+  date: "2024-04-16"
+  source_url: "https://ijcai24.org/call-for-papers/index.html"
 venue: "IJCAI"
 paper_url: "https://www.ijcai.org/proceedings/2024/0769"
 code_url: "https://github.com/Zhuoyi-Lin/Cross_problem_learning"

--- a/generalist/goal.md
+++ b/generalist/goal.md
@@ -8,6 +8,9 @@ authors:
   - Jean-Marc Andreoli
 year: 2025
 date: 2024-06-21
+acceptance:
+  date: "2025-01-22"
+  source_url: "https://iclr.cc/Conferences/2025/Dates"
 venue: ICLR
 paper_url: https://openreview.net/forum?id=z2z9suDRjw
 arxiv_url: https://arxiv.org/abs/2406.15079

--- a/generalist/mixed-curvature.md
+++ b/generalist/mixed-curvature.md
@@ -9,6 +9,9 @@ authors:
   - "Yew-Soon Ong"
 year: 2025
 date: 2025-01-28
+acceptance:
+  date: "2025-05-01"
+  source_url: "https://icml.cc/Conferences/2025/Dates"
 venue: "ICML"
 paper_url: "https://proceedings.mlr.press/v267/liu25b.html"
 institutions:

--- a/generalist/mtl-kd.md
+++ b/generalist/mtl-kd.md
@@ -10,6 +10,9 @@ authors:
   - "Yu Zhou"
 year: 2025
 date: 2025-06-03
+acceptance:
+  date: "2025-09-18"
+  source_url: "https://neurips.cc/Conferences/2025/CallForPapers"
 venue: "NeurIPS"
 paper_url: "https://proceedings.neurips.cc/paper_files/paper/2025/hash/899c6a43b9976e1077522fe5a39cafa3-Abstract-Conference.html"
 code_url: "https://github.com/CIAM-Group/MTLKD"

--- a/generalist/mtpomo.md
+++ b/generalist/mtpomo.md
@@ -11,6 +11,9 @@ authors:
   - "Mingxuan Yuan"
 year: 2024
 date: 2024-02-23
+acceptance:
+  date: "2024-05-16"
+  source_url: "https://www.kdd.org/kdd2024/research-track-call-for-papers/"
 venue: "KDD"
 paper_url: "https://doi.org/10.1145/3637528.3672040"
 arxiv_url: "https://arxiv.org/abs/2402.16891"

--- a/generalist/mvmoe.md
+++ b/generalist/mvmoe.md
@@ -12,6 +12,9 @@ authors:
   - "Chi Xu"
 year: 2024
 date: 2024-05-02
+acceptance:
+  date: "2024-05-01"
+  source_url: "https://icml.cc/Conferences/2024/Dates"
 venue: "ICML"
 paper_url: "https://proceedings.mlr.press/v235/zhou24c.html"
 arxiv_url: "https://arxiv.org/abs/2405.01029"

--- a/generalist/routefinder.md
+++ b/generalist/routefinder.md
@@ -14,6 +14,9 @@ authors:
   - "Jinkyoo Park"
 year: 2025
 date: 2024-06-21
+acceptance:
+  date: "2025-08"
+  source_url: "https://openreview.net/forum?id=QzGLoaOPiY"
 venue: "TMLR"
 paper_url: "https://openreview.net/forum?id=QzGLoaOPiY"
 arxiv_url: "https://arxiv.org/abs/2406.15007"

--- a/generalist/shield.md
+++ b/generalist/shield.md
@@ -11,6 +11,9 @@ authors:
   - "Wee Sun Lee"
 year: 2025
 date: 2025-06-10
+acceptance:
+  date: "2025-05-01"
+  source_url: "https://icml.cc/Conferences/2025/Dates"
 venue: "ICML"
 paper_url: "https://proceedings.mlr.press/v267/goh25a.html"
 arxiv_url: "https://arxiv.org/abs/2506.08424"

--- a/generalist/urs.md
+++ b/generalist/urs.md
@@ -12,6 +12,9 @@ authors:
   - "Qingfu Zhang"
 year: 2026
 date: 2025-09-27
+acceptance:
+  date: "2026-04-30"
+  source_url: "https://icml.cc/Conferences/2026/Dates"
 venue: "ICML"
 paper_url: "https://icml.cc/virtual/2026/poster/61527"
 arxiv_url: "https://arxiv.org/abs/2509.23413"

--- a/scripts/content-lib.mjs
+++ b/scripts/content-lib.mjs
@@ -19,12 +19,34 @@ export const requiredSections = [
 ]
 
 const isoDate = /^\d{4}-\d{2}-\d{2}$/
+const partialIsoDate = /^\d{4}(?:-\d{2}(?:-\d{2})?)?$/
 
 function isRealIsoDate(value) {
   if (!isoDate.test(value)) return false
   const date = new Date(`${value}T00:00:00Z`)
   return !Number.isNaN(date.valueOf()) && date.toISOString().slice(0, 10) === value
 }
+
+function isRealPartialIsoDate(value) {
+  if (!partialIsoDate.test(value)) return false
+  const year = Number(value.slice(0, 4))
+  if (year < 1900 || year > 2200) return false
+  if (value.length === 4) return true
+
+  const month = Number(value.slice(5, 7))
+  if (month < 1 || month > 12) return false
+  if (value.length === 7) return true
+
+  return isRealIsoDate(value)
+}
+
+const acceptanceSchema = z.object({
+  date: z.preprocess(
+    (value) => value instanceof Date ? value.toISOString().slice(0, 10) : typeof value === 'number' ? String(value) : value,
+    z.string().refine(isRealPartialIsoDate, 'acceptance.date must be a real YYYY, YYYY-MM, or YYYY-MM-DD date'),
+  ),
+  source_url: z.string().url(),
+}).strict()
 
 export const paperSchema = z.object({
   id: z.string().regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/),
@@ -36,6 +58,7 @@ export const paperSchema = z.object({
     (value) => value instanceof Date ? value.toISOString().slice(0, 10) : value,
     z.string().refine(isRealIsoDate, 'date must be a real YYYY-MM-DD date'),
   ),
+  acceptance: acceptanceSchema.optional(),
   venue: z.string().min(1),
   paper_url: z.string().url(),
   arxiv_url: z.string().url().optional(),
@@ -52,7 +75,22 @@ export const paperSchema = z.object({
     caption: z.string().min(1),
     source_url: z.string().url(),
   }).strict().optional(),
-}).strict()
+}).strict().superRefine((paper, context) => {
+  if (paper.venue === 'arXiv' && paper.acceptance) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['acceptance'],
+      message: 'arXiv-only papers must not declare acceptance metadata',
+    })
+  }
+  if (paper.venue !== 'arXiv' && !paper.acceptance) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['acceptance'],
+      message: 'formally published papers must declare acceptance metadata',
+    })
+  }
+})
 
 export const relationSchema = z.object({
   papers: z.tuple([z.string().min(1), z.string().min(1)]),
@@ -96,7 +134,8 @@ export function renderMarkdown(markdown) {
 }
 
 export function parsePaper(raw, { filePath, expectedScope }) {
-  const parsed = matter(raw, { engines: { yaml: (source) => YAML.parse(source) } })
+  const normalizedRaw = raw.replace(/\r\n?/g, '\n')
+  const parsed = matter(normalizedRaw, { engines: { yaml: (source) => YAML.parse(source) } })
   const metadata = paperSchema.parse(parsed.data)
   const filename = path.basename(filePath, path.extname(filePath))
 
@@ -120,7 +159,25 @@ export function parsePaper(raw, { filePath, expectedScope }) {
   }
 }
 
+function sortablePartialDate(date) {
+  if (date.length === 4) return `${date}-00-00`
+  if (date.length === 7) return `${date}-00`
+  return date
+}
+
+export function timelineDate(paper) {
+  return paper.acceptance?.date ?? paper.date
+}
+
 export function sortPapersNewestFirst(papers) {
+  return [...papers].sort((first, second) => (
+    sortablePartialDate(timelineDate(second)).localeCompare(sortablePartialDate(timelineDate(first)))
+    || second.date.localeCompare(first.date)
+    || first.title.localeCompare(second.title)
+  ))
+}
+
+export function sortPapersByFirstPublicNewestFirst(papers) {
   return [...papers].sort((first, second) => second.date.localeCompare(first.date) || first.title.localeCompare(second.title))
 }
 
@@ -198,5 +255,5 @@ export async function loadRelations(root = process.cwd(), papers) {
 export async function loadContent(root = process.cwd()) {
   const papers = await loadPapers(root)
   const relations = await loadRelations(root, papers)
-  return { version: 2, papers, relations }
+  return { version: 3, papers, relations }
 }

--- a/scripts/index-lib.mjs
+++ b/scripts/index-lib.mjs
@@ -10,7 +10,8 @@ const paradigmLabels = {
 export function renderPaperIndex(papers) {
   if (papers.length === 0) return '_No papers have been added yet._'
 
-  const sorted = [...papers].sort((first, second) => second.date.localeCompare(first.date) || first.title.localeCompare(second.title))
+  const timelineDate = (paper) => paper.acceptance?.date ?? paper.date
+  const sorted = [...papers].sort((first, second) => timelineDate(second).localeCompare(timelineDate(first)) || second.date.localeCompare(first.date) || first.title.localeCompare(second.title))
   return sorted.map((paper) => [
     `### [${paper.title}](${paper.id}.md)`,
     '',
@@ -18,7 +19,8 @@ export function renderPaperIndex(papers) {
     `- **Problems:** ${paper.problems.join('; ')}`,
     `- **Venue:** ${paper.venue}`,
     `- **Year:** ${paper.year}`,
-    `- **First public:** ${paper.date}`,
+    `- **Accepted:** ${paper.acceptance ? `[${paper.acceptance.date}](${paper.acceptance.source_url})` : '—'}`,
+    `- **arXiv:** ${paper.arxiv_url ? `[${paper.date}](${paper.arxiv_url})` : '—'}`,
     `- **Institutions:** ${paper.institutions.join('; ')}`,
   ].join('\n')).join('\n\n')
 }

--- a/specialist/README.md
+++ b/specialist/README.md
@@ -25,8 +25,29 @@ Select a paper title to open its research note.
 - **Problems:** Capacitated Vehicle Routing Problem
 - **Venue:** ICLR
 - **Year:** 2026
-- **First public:** 2025-06-22
+- **Accepted:** [2026-01-25](https://iclr.cc/Conferences/2026/Dates)
+- **arXiv:** [2025-06-22](https://arxiv.org/abs/2507.01037)
 - **Institutions:** Massachusetts Institute of Technology
+
+### [Instance-Conditioned Adaptation for Large-Scale Generalization of Neural Routing Solver](icam.md)
+
+- **Paradigm:** Constructive
+- **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem; Asymmetric Traveling Salesman Problem
+- **Venue:** IEEE T-ITS
+- **Year:** 2026
+- **Accepted:** [2026](https://doi.org/10.1109/TITS.2026.3674538)
+- **arXiv:** [2024-05-03](https://arxiv.org/abs/2405.01906)
+- **Institutions:** Southern University of Science and Technology; City University of Hong Kong
+
+### [Learning to Reduce Search Space for Generalizable Neural Routing Solver](l2r.md)
+
+- **Paradigm:** Constructive
+- **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem
+- **Venue:** KDD
+- **Year:** 2026
+- **Accepted:** [2025-11-23](https://kdd2026.kdd.org/research-track-call-for-papers/)
+- **arXiv:** [2025-03-05](https://arxiv.org/abs/2503.03137)
+- **Institutions:** Southern University of Science and Technology; City University of Hong Kong
 
 ### [Improving Generalization of Neural Combinatorial Optimization for Vehicle Routing Problems via Test-Time Projection Learning](ttpl.md)
 
@@ -34,7 +55,8 @@ Select a paper title to open its research note.
 - **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem
 - **Venue:** NeurIPS
 - **Year:** 2025
-- **First public:** 2025-06-03
+- **Accepted:** [2025-09-18](https://neurips.cc/Conferences/2025/CallForPapers)
+- **arXiv:** [2025-06-03](https://arxiv.org/abs/2506.02392)
 - **Institutions:** Southern University of Science and Technology
 
 ### [Rethinking Neural Combinatorial Optimization for Vehicle Routing Problems with Different Constraint Tightness Degrees](constraint-tightness.md)
@@ -43,7 +65,8 @@ Select a paper title to open its research note.
 - **Problems:** Capacitated Vehicle Routing Problem; Vehicle Routing Problem with Time Windows
 - **Venue:** NeurIPS
 - **Year:** 2025
-- **First public:** 2025-05-30
+- **Accepted:** [2025-09-18](https://neurips.cc/Conferences/2025/CallForPapers)
+- **arXiv:** [2025-05-30](https://arxiv.org/abs/2505.24627)
 - **Institutions:** Southern University of Science and Technology
 
 ### [Generation as Search Operator for Test-Time Scaling of Diffusion-Based Combinatorial Optimization](gensco.md)
@@ -52,7 +75,8 @@ Select a paper title to open its research note.
 - **Problems:** Traveling Salesman Problem
 - **Venue:** NeurIPS
 - **Year:** 2025
-- **First public:** 2025-05-23
+- **Accepted:** [2025-09-18](https://neurips.cc/Conferences/2025/CallForPapers)
+- **arXiv:** —
 - **Institutions:** Shanghai Jiao Tong University
 
 ### [Learning to Insert for Constructive Neural Vehicle Routing Solver](l2c-insert.md)
@@ -61,35 +85,9 @@ Select a paper title to open its research note.
 - **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem
 - **Venue:** NeurIPS
 - **Year:** 2025
-- **First public:** 2025-05-20
+- **Accepted:** [2025-09-18](https://neurips.cc/Conferences/2025/CallForPapers)
+- **arXiv:** [2025-05-20](https://arxiv.org/abs/2505.13904)
 - **Institutions:** Southern University of Science and Technology
-
-### [Learning to Reduce Search Space for Generalizable Neural Routing Solver](l2r.md)
-
-- **Paradigm:** Constructive
-- **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem
-- **Venue:** KDD
-- **Year:** 2026
-- **First public:** 2025-03-05
-- **Institutions:** Southern University of Science and Technology; City University of Hong Kong
-
-### [Destroy and Repair Using Hyper-Graphs for Routing](drhg.md)
-
-- **Paradigm:** Improvement
-- **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem
-- **Venue:** AAAI
-- **Year:** 2025
-- **First public:** 2025-02-22
-- **Institutions:** Southern University of Science and Technology
-
-### [DGL: Dynamic Global-Local Information Aggregation for Scalable VRP Generalization with Self-Improvement Learning](dgl.md)
-
-- **Paradigm:** Constructive
-- **Problems:** Capacitated Vehicle Routing Problem
-- **Venue:** IJCAI
-- **Year:** 2025
-- **First public:** 2025-01-15
-- **Institutions:** Nanyang Technological University
 
 ### [Neural Deconstruction Search for Vehicle Routing Problems](nds.md)
 
@@ -97,25 +95,18 @@ Select a paper title to open its research note.
 - **Problems:** Capacitated Vehicle Routing Problem; Vehicle Routing Problem with Time Windows
 - **Venue:** TMLR
 - **Year:** 2025
-- **First public:** 2025-01-07
+- **Accepted:** [2025-05-05](https://openreview.net/forum?id=bCmEP1Ltwq)
+- **arXiv:** [2025-01-07](https://arxiv.org/abs/2501.03715)
 - **Institutions:** TU Dortmund University
 
-### [Fast T2T: Optimization Consistency Speeds Up Diffusion-Based Training-to-Testing Solving for Combinatorial Optimization](fast-t2t.md)
+### [DGL: Dynamic Global-Local Information Aggregation for Scalable VRP Generalization with Self-Improvement Learning](dgl.md)
 
 - **Paradigm:** Constructive
-- **Problems:** Traveling Salesman Problem
-- **Venue:** NeurIPS
-- **Year:** 2024
-- **First public:** 2024-12-09
-- **Institutions:** Shanghai Jiao Tong University
-
-### [Learning to Handle Complex Constraints for Vehicle Routing Problems](pip.md)
-
-- **Paradigm:** Constructive
-- **Problems:** Vehicle Routing Problem with Time Windows; Orienteering Problem
-- **Venue:** NeurIPS
-- **Year:** 2024
-- **First public:** 2024-10-28
+- **Problems:** Capacitated Vehicle Routing Problem
+- **Venue:** IJCAI
+- **Year:** 2025
+- **Accepted:** [2025-04-28](https://2025.ijcai.org/important-dates/)
+- **arXiv:** —
 - **Institutions:** Nanyang Technological University
 
 ### [Adversarial Generative Flow Network for Solving Vehicle Routing Problems](agfn.md)
@@ -124,7 +115,18 @@ Select a paper title to open its research note.
 - **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem
 - **Venue:** ICLR
 - **Year:** 2025
-- **First public:** 2024-09-28
+- **Accepted:** [2025-01-22](https://iclr.cc/Conferences/2025/Dates)
+- **arXiv:** [2025-03-03](https://arxiv.org/abs/2503.01931)
+- **Institutions:** Nanyang Technological University
+
+### [Rethinking Light Decoder-based Solvers for Vehicle Routing Problems](reld.md)
+
+- **Paradigm:** Constructive
+- **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem
+- **Venue:** ICLR
+- **Year:** 2025
+- **Accepted:** [2025-01-22](https://iclr.cc/Conferences/2025/Dates)
+- **arXiv:** [2025-03-02](https://arxiv.org/abs/2503.00753)
 - **Institutions:** Nanyang Technological University
 
 ### [Boosting Neural Combinatorial Optimization for Large-Scale Vehicle Routing Problems](sil.md)
@@ -133,26 +135,69 @@ Select a paper title to open its research note.
 - **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem
 - **Venue:** ICLR
 - **Year:** 2025
-- **First public:** 2024-09-26
+- **Accepted:** [2025-01-22](https://iclr.cc/Conferences/2025/Dates)
+- **arXiv:** —
 - **Institutions:** Southern University of Science and Technology
 
-### [Rethinking Light Decoder-based Solvers for Vehicle Routing Problems](reld.md)
+### [PolyNet: Learning Diverse Solution Strategies for Neural Combinatorial Optimization](polynet.md)
 
 - **Paradigm:** Constructive
 - **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem
 - **Venue:** ICLR
 - **Year:** 2025
-- **First public:** 2024-09-26
-- **Institutions:** Nanyang Technological University
+- **Accepted:** [2025-01-22](https://iclr.cc/Conferences/2025/Dates)
+- **arXiv:** [2024-02-21](https://arxiv.org/abs/2402.14048)
+- **Institutions:** TU Dortmund University
 
-### [Hierarchical Neural Constructive Solver for Real-world TSP Scenarios](hncs.md)
+### [Ant Colony Sampling with GFlowNets for Combinatorial Optimization](gfacs.md)
+
+- **Paradigm:** Constructive + Improvement
+- **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem
+- **Venue:** AISTATS
+- **Year:** 2025
+- **Accepted:** [2025-01-21](https://aistats.org/aistats2025/dates.html)
+- **arXiv:** [2024-03-11](https://arxiv.org/abs/2403.07041)
+- **Institutions:** KAIST; Mila
+
+### [Distance-Aware Attention Reshaping for Enhancing Generalization of Neural Solvers](dar.md)
+
+- **Paradigm:** Constructive
+- **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem
+- **Venue:** IEEE TNNLS
+- **Year:** 2025
+- **Accepted:** [2025](https://doi.org/10.1109/TNNLS.2025.3588209)
+- **arXiv:** —
+- **Institutions:** South China University of Technology; Victoria University of Wellington
+
+### [Destroy and Repair Using Hyper-Graphs for Routing](drhg.md)
+
+- **Paradigm:** Improvement
+- **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem
+- **Venue:** AAAI
+- **Year:** 2025
+- **Accepted:** [2024-12-09](https://aaai.org/conference/aaai/aaai-25/)
+- **arXiv:** [2025-02-22](https://arxiv.org/abs/2502.16170)
+- **Institutions:** Southern University of Science and Technology
+
+### [Fast T2T: Optimization Consistency Speeds Up Diffusion-Based Training-to-Testing Solving for Combinatorial Optimization](fast-t2t.md)
 
 - **Paradigm:** Constructive
 - **Problems:** Traveling Salesman Problem
-- **Venue:** KDD
+- **Venue:** NeurIPS
 - **Year:** 2024
-- **First public:** 2024-08-07
-- **Institutions:** National University of Singapore
+- **Accepted:** [2024-09-25](https://neurips.cc/Conferences/2024/CallForPapers)
+- **arXiv:** [2025-02-05](https://arxiv.org/abs/2502.02941)
+- **Institutions:** Shanghai Jiao Tong University
+
+### [Learning to Handle Complex Constraints for Vehicle Routing Problems](pip.md)
+
+- **Paradigm:** Constructive
+- **Problems:** Vehicle Routing Problem with Time Windows; Orienteering Problem
+- **Venue:** NeurIPS
+- **Year:** 2024
+- **Accepted:** [2024-09-25](https://neurips.cc/Conferences/2024/CallForPapers)
+- **arXiv:** [2024-10-28](https://arxiv.org/abs/2410.21066)
+- **Institutions:** Nanyang Technological University
 
 ### [UDC: A Unified Neural Divide-and-Conquer Framework for Large-Scale Combinatorial Optimization Problems](udc.md)
 
@@ -160,8 +205,29 @@ Select a paper title to open its research note.
 - **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem
 - **Venue:** NeurIPS
 - **Year:** 2024
-- **First public:** 2024-07-01
+- **Accepted:** [2024-09-25](https://neurips.cc/Conferences/2024/CallForPapers)
+- **arXiv:** [2024-06-29](https://arxiv.org/abs/2407.00312)
 - **Institutions:** Southern University of Science and Technology
+
+### [Self-Improvement for Neural Combinatorial Optimization: Sample without Replacement, but Improvement](gumbeldore.md)
+
+- **Paradigm:** Constructive
+- **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem
+- **Venue:** TMLR
+- **Year:** 2024
+- **Accepted:** [2024-06](https://openreview.net/forum?id=agT8ojoH0X)
+- **arXiv:** [2024-03-22](https://arxiv.org/abs/2403.15180)
+- **Institutions:** German Cancer Research Center
+
+### [Hierarchical Neural Constructive Solver for Real-world TSP Scenarios](hncs.md)
+
+- **Paradigm:** Constructive
+- **Problems:** Traveling Salesman Problem
+- **Venue:** KDD
+- **Year:** 2024
+- **Accepted:** [2024-05-16](https://www.kdd.org/kdd2024/research-track-call-for-papers/)
+- **arXiv:** [2024-08-07](https://arxiv.org/abs/2408.03585)
+- **Institutions:** National University of Singapore
 
 ### [Position: Rethinking Post-Hoc Search-Based Neural Approaches for Solving Large-Scale Traveling Salesman Problems](softdist.md)
 
@@ -169,7 +235,8 @@ Select a paper title to open its research note.
 - **Problems:** Traveling Salesman Problem
 - **Venue:** ICML
 - **Year:** 2024
-- **First public:** 2024-06-02
+- **Accepted:** [2024-05-01](https://icml.cc/Conferences/2024/Dates)
+- **arXiv:** [2024-06-02](https://arxiv.org/abs/2406.03503)
 - **Institutions:** Microsoft Research Asia
 
 ### [DPN: Decoupling Partition and Navigation for Neural Solvers of Min-max Vehicle Routing Problems](dpn.md)
@@ -178,17 +245,19 @@ Select a paper title to open its research note.
 - **Problems:** Min-max Multiple Traveling Salesman Problem
 - **Venue:** ICML
 - **Year:** 2024
-- **First public:** 2024-05-27
+- **Accepted:** [2024-05-01](https://icml.cc/Conferences/2024/Dates)
+- **arXiv:** [2024-05-27](https://arxiv.org/abs/2405.17272)
 - **Institutions:** Southern University of Science and Technology
 
-### [Instance-Conditioned Adaptation for Large-Scale Generalization of Neural Routing Solver](icam.md)
+### [INViT: A Generalizable Routing Problem Solver with Invariant Nested View Transformer](invit.md)
 
 - **Paradigm:** Constructive
-- **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem; Asymmetric Traveling Salesman Problem
-- **Venue:** IEEE T-ITS
-- **Year:** 2026
-- **First public:** 2024-05-03
-- **Institutions:** Southern University of Science and Technology; City University of Hong Kong
+- **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem
+- **Venue:** ICML
+- **Year:** 2024
+- **Accepted:** [2024-05-01](https://icml.cc/Conferences/2024/Dates)
+- **arXiv:** [2024-02-04](https://arxiv.org/abs/2402.02317)
+- **Institutions:** Shanghai Jiao Tong University
 
 ### [Towards Generalizable Neural Solvers for Vehicle Routing Problems via Ensemble with Transferable Local Policy](elg.md)
 
@@ -196,7 +265,8 @@ Select a paper title to open its research note.
 - **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem
 - **Venue:** IJCAI
 - **Year:** 2024
-- **First public:** 2024-04-11
+- **Accepted:** [2024-04-16](https://ijcai24.org/call-for-papers/index.html)
+- **arXiv:** —
 - **Institutions:** University of Science and Technology of China
 
 ### [Less Is More -- On the Importance of Sparsification for Transformers and Graph Neural Networks for TSP](less-is-more.md)
@@ -205,44 +275,29 @@ Select a paper title to open its research note.
 - **Problems:** Traveling Salesman Problem
 - **Venue:** arXiv
 - **Year:** 2024
-- **First public:** 2024-03-25
+- **Accepted:** —
+- **arXiv:** [2024-03-25](https://arxiv.org/abs/2403.17159)
 - **Institutions:** Chalmers University of Technology
 
-### [Self-Improvement for Neural Combinatorial Optimization: Sample without Replacement, but Improvement](gumbeldore.md)
+### [Efficient Neural Collaborative Search for Pickup and Delivery Problems](ncs.md)
 
-- **Paradigm:** Constructive
-- **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem
-- **Venue:** TMLR
+- **Paradigm:** Improvement
+- **Problems:** Pickup and Delivery Problem; Pickup and Delivery Problem with Time Windows
+- **Venue:** IEEE TPAMI
 - **Year:** 2024
-- **First public:** 2024-03-22
-- **Institutions:** German Cancer Research Center
+- **Accepted:** [2024](https://doi.org/10.1109/TPAMI.2024.3450850)
+- **arXiv:** —
+- **Institutions:** Nanyang Technological University
 
-### [Ant Colony Sampling with GFlowNets for Combinatorial Optimization](gfacs.md)
-
-- **Paradigm:** Constructive + Improvement
-- **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem
-- **Venue:** AISTATS
-- **Year:** 2025
-- **First public:** 2024-03-11
-- **Institutions:** KAIST; Mila
-
-### [PolyNet: Learning Diverse Solution Strategies for Neural Combinatorial Optimization](polynet.md)
+### [ASP: Learn a Universal Neural Solver!](asp.md)
 
 - **Paradigm:** Constructive
 - **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem
-- **Venue:** ICLR
-- **Year:** 2025
-- **First public:** 2024-02-21
-- **Institutions:** TU Dortmund University
-
-### [INViT: A Generalizable Routing Problem Solver with Invariant Nested View Transformer](invit.md)
-
-- **Paradigm:** Constructive
-- **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem
-- **Venue:** ICML
+- **Venue:** IEEE TPAMI
 - **Year:** 2024
-- **First public:** 2024-02-04
-- **Institutions:** Shanghai Jiao Tong University
+- **Accepted:** [2024](https://doi.org/10.1109/TPAMI.2024.3352096)
+- **arXiv:** [2023-03-01](https://arxiv.org/abs/2303.00466)
+- **Institutions:** Peking University
 
 ### [GLOP: Learning Global Partition and Local Construction for Solving Large-Scale Routing Problems in Real-Time](glop.md)
 
@@ -250,7 +305,8 @@ Select a paper title to open its research note.
 - **Problems:** Traveling Salesman Problem; Asymmetric Traveling Salesman Problem; Capacitated Vehicle Routing Problem; Prize Collecting Traveling Salesman Problem
 - **Venue:** AAAI
 - **Year:** 2024
-- **First public:** 2023-12-13
+- **Accepted:** [2023-12-09](https://aaai.org/conference/aaai/aaai-24/)
+- **arXiv:** [2023-12-13](https://arxiv.org/abs/2312.08224)
 - **Institutions:** Soochow University; Singapore Management University
 
 ### [T2T: From Distribution Learning in Training to Gradient Search in Testing for Combinatorial Optimization](t2t.md)
@@ -259,7 +315,8 @@ Select a paper title to open its research note.
 - **Problems:** Traveling Salesman Problem
 - **Venue:** NeurIPS
 - **Year:** 2023
-- **First public:** 2023-12-11
+- **Accepted:** [2023-09-21](https://neurips.cc/Conferences/2023/CallForPapers)
+- **arXiv:** —
 - **Institutions:** Shanghai Jiao Tong University
 
 ### [Combinatorial Optimization with Policy Adaptation using Latent Space Search](compass.md)
@@ -268,17 +325,9 @@ Select a paper title to open its research note.
 - **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem
 - **Venue:** NeurIPS
 - **Year:** 2023
-- **First public:** 2023-11-13
+- **Accepted:** [2023-09-21](https://neurips.cc/Conferences/2023/CallForPapers)
+- **arXiv:** [2023-11-13](https://arxiv.org/abs/2311.13569)
 - **Institutions:** InstaDeep
-
-### [Distance-Aware Attention Reshaping for Enhancing Generalization of Neural Solvers](dar.md)
-
-- **Paradigm:** Constructive
-- **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem
-- **Venue:** IEEE TNNLS
-- **Year:** 2025
-- **First public:** 2023-11-01
-- **Institutions:** South China University of Technology; Victoria University of Wellington
 
 ### [Learning to Search Feasible and Infeasible Regions of Routing Problems with Flexible Neural k-Opt](neuopt.md)
 
@@ -286,7 +335,8 @@ Select a paper title to open its research note.
 - **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem
 - **Venue:** NeurIPS
 - **Year:** 2023
-- **First public:** 2023-10-27
+- **Accepted:** [2023-09-21](https://neurips.cc/Conferences/2023/CallForPapers)
+- **arXiv:** [2023-10-27](https://arxiv.org/abs/2310.18264)
 - **Institutions:** Nanyang Technological University
 
 ### [Neural Combinatorial Optimization with Heavy Decoder: Toward Large Scale Generalization](lehd.md)
@@ -295,7 +345,8 @@ Select a paper title to open its research note.
 - **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem
 - **Venue:** NeurIPS
 - **Year:** 2023
-- **First public:** 2023-10-12
+- **Accepted:** [2023-09-21](https://neurips.cc/Conferences/2023/CallForPapers)
+- **arXiv:** [2023-10-12](https://arxiv.org/abs/2310.07985)
 - **Institutions:** Southern University of Science and Technology; City University of Hong Kong
 
 ### [DeepACO: Neural-enhanced Ant Systems for Combinatorial Optimization](deepaco.md)
@@ -304,26 +355,39 @@ Select a paper title to open its research note.
 - **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem; Orienteering Problem; Prize Collecting Traveling Salesman Problem; Sequential Ordering Problem; Single Machine Total Weighted Tardiness Problem; Resource-Constrained Project Scheduling Problem; Multiple Knapsack Problem
 - **Venue:** NeurIPS
 - **Year:** 2023
-- **First public:** 2023-09-25
+- **Accepted:** [2023-09-21](https://neurips.cc/Conferences/2023/CallForPapers)
+- **arXiv:** [2023-09-25](https://arxiv.org/abs/2309.14032)
 - **Institutions:** Soochow University; Singapore Management University; Tsinghua University
 
-### [Efficient Neural Collaborative Search for Pickup and Delivery Problems](ncs.md)
+### [Unsupervised Learning for Solving the Travelling Salesman Problem](utsp.md)
 
-- **Paradigm:** Improvement
-- **Problems:** Pickup and Delivery Problem; Pickup and Delivery Problem with Time Windows
-- **Venue:** IEEE TPAMI
-- **Year:** 2024
-- **First public:** 2023-08-01
-- **Institutions:** Nanyang Technological University
+- **Paradigm:** Constructive
+- **Problems:** Traveling Salesman Problem
+- **Venue:** NeurIPS
+- **Year:** 2023
+- **Accepted:** [2023-09-21](https://neurips.cc/Conferences/2023/CallForPapers)
+- **arXiv:** [2023-03-19](https://arxiv.org/abs/2303.10538)
+- **Institutions:** Cornell University
 
-### [Learning Feature Embedding Refiner for Solving Vehicle Routing Problems](fer.md)
+### [DIFUSCO: Graph-based Diffusion Solvers for Combinatorial Optimization](difusco.md)
+
+- **Paradigm:** Constructive
+- **Problems:** Traveling Salesman Problem
+- **Venue:** NeurIPS
+- **Year:** 2023
+- **Accepted:** [2023-09-21](https://neurips.cc/Conferences/2023/CallForPapers)
+- **arXiv:** [2023-02-16](https://arxiv.org/abs/2302.08224)
+- **Institutions:** Carnegie Mellon University
+
+### [BQ-NCO: Bisimulation Quotienting for Efficient Neural Combinatorial Optimization](bq-nco.md)
 
 - **Paradigm:** Constructive
 - **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem
-- **Venue:** IEEE TNNLS
-- **Year:** 2024
-- **First public:** 2023-06-15
-- **Institutions:** Nanyang Technological University
+- **Venue:** NeurIPS
+- **Year:** 2023
+- **Accepted:** [2023-09-21](https://neurips.cc/Conferences/2023/CallForPapers)
+- **arXiv:** [2023-01-09](https://arxiv.org/abs/2301.03313)
+- **Institutions:** NAVER LABS Europe
 
 ### [Meta-SAGE: Scale Meta-Learning Scheduled Adaptation with Guided Exploration for Mitigating Scale Shift on Combinatorial Optimization](meta-sage.md)
 
@@ -331,7 +395,8 @@ Select a paper title to open its research note.
 - **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem
 - **Venue:** ICML
 - **Year:** 2023
-- **First public:** 2023-06-05
+- **Accepted:** [2023-04-24](https://icml.cc/Conferences/2023/Dates)
+- **arXiv:** [2023-06-05](https://arxiv.org/abs/2306.02688)
 - **Institutions:** KAIST
 
 ### [Towards Omni-generalizable Neural Methods for Vehicle Routing Problems](omni-vrp.md)
@@ -340,8 +405,19 @@ Select a paper title to open its research note.
 - **Problems:** Capacitated Vehicle Routing Problem; Vehicle Routing Problem with Time Windows
 - **Venue:** ICML
 - **Year:** 2023
-- **First public:** 2023-05-31
+- **Accepted:** [2023-04-24](https://icml.cc/Conferences/2023/Dates)
+- **arXiv:** [2023-05-31](https://arxiv.org/abs/2305.19587)
 - **Institutions:** Nanyang Technological University
+
+### [Generalize Learned Heuristics to Solve Large-scale Vehicle Routing Problems in Real-time](tam.md)
+
+- **Paradigm:** Constructive
+- **Problems:** Capacitated Vehicle Routing Problem; Traveling Salesman Problem
+- **Venue:** ICLR
+- **Year:** 2023
+- **Accepted:** [2023-01-21](https://iclr.cc/Conferences/2023/Dates)
+- **arXiv:** —
+- **Institutions:** Alibaba Group
 
 ### [Select and Optimize: Learning to Solve Large-Scale TSP Instances](select-and-optimize.md)
 
@@ -349,8 +425,19 @@ Select a paper title to open its research note.
 - **Problems:** Traveling Salesman Problem
 - **Venue:** AISTATS
 - **Year:** 2023
-- **First public:** 2023-04-25
+- **Accepted:** [2023-01-19](https://aistats.org/aistats2023/)
+- **arXiv:** —
 - **Institutions:** Hikvision Research Institute
+
+### [Learning Feature Embedding Refiner for Solving Vehicle Routing Problems](fer.md)
+
+- **Paradigm:** Constructive
+- **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem
+- **Venue:** IEEE TNNLS
+- **Year:** 2024
+- **Accepted:** [2023](https://doi.org/10.1109/TNNLS.2023.3285077)
+- **arXiv:** —
+- **Institutions:** Nanyang Technological University
 
 ### [H-TSP: Hierarchically Solving the Large-Scale Traveling Salesman Problem](h-tsp.md)
 
@@ -358,7 +445,8 @@ Select a paper title to open its research note.
 - **Problems:** Traveling Salesman Problem
 - **Venue:** AAAI
 - **Year:** 2023
-- **First public:** 2023-04-19
+- **Accepted:** [2022-11-18](https://aaai-23.aaai.org/aaai23call/)
+- **arXiv:** [2023-04-19](https://arxiv.org/abs/2304.09395)
 - **Institutions:** Huazhong University of Science and Technology; Microsoft Research Asia
 
 ### [Pointerformer: Deep Reinforced Multi-Pointer Transformer for the Traveling Salesman Problem](pointerformer.md)
@@ -367,53 +455,9 @@ Select a paper title to open its research note.
 - **Problems:** Traveling Salesman Problem
 - **Venue:** AAAI
 - **Year:** 2023
-- **First public:** 2023-04-19
+- **Accepted:** [2022-11-18](https://aaai-23.aaai.org/aaai23call/)
+- **arXiv:** [2023-04-19](https://arxiv.org/abs/2304.09407)
 - **Institutions:** Huazhong University of Science and Technology; Microsoft Research Asia
-
-### [Unsupervised Learning for Solving the Travelling Salesman Problem](utsp.md)
-
-- **Paradigm:** Constructive
-- **Problems:** Traveling Salesman Problem
-- **Venue:** NeurIPS
-- **Year:** 2023
-- **First public:** 2023-03-19
-- **Institutions:** Cornell University
-
-### [ASP: Learn a Universal Neural Solver!](asp.md)
-
-- **Paradigm:** Constructive
-- **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem
-- **Venue:** IEEE TPAMI
-- **Year:** 2024
-- **First public:** 2023-03-01
-- **Institutions:** Peking University
-
-### [DIFUSCO: Graph-based Diffusion Solvers for Combinatorial Optimization](difusco.md)
-
-- **Paradigm:** Constructive
-- **Problems:** Traveling Salesman Problem
-- **Venue:** NeurIPS
-- **Year:** 2023
-- **First public:** 2023-02-16
-- **Institutions:** Carnegie Mellon University
-
-### [Generalize Learned Heuristics to Solve Large-scale Vehicle Routing Problems in Real-time](tam.md)
-
-- **Paradigm:** Constructive
-- **Problems:** Capacitated Vehicle Routing Problem; Traveling Salesman Problem
-- **Venue:** ICLR
-- **Year:** 2023
-- **First public:** 2023-02-01
-- **Institutions:** Alibaba Group
-
-### [BQ-NCO: Bisimulation Quotienting for Efficient Neural Combinatorial Optimization](bq-nco.md)
-
-- **Paradigm:** Constructive
-- **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem
-- **Venue:** NeurIPS
-- **Year:** 2023
-- **First public:** 2023-01-09
-- **Institutions:** NAVER LABS Europe
 
 ### [DIMES: A Differentiable Meta Solver for Combinatorial Optimization Problems](dimes.md)
 
@@ -421,17 +465,9 @@ Select a paper title to open its research note.
 - **Problems:** Traveling Salesman Problem; Maximum Independent Set
 - **Venue:** NeurIPS
 - **Year:** 2022
-- **First public:** 2022-10-08
+- **Accepted:** [2022-09-14](https://neurips.cc/Conferences/2022/CallForPapers)
+- **arXiv:** [2022-10-08](https://arxiv.org/abs/2210.04123)
 - **Institutions:** Carnegie Mellon University
-
-### [RBG: Hierarchically Solving Large-Scale Routing Problems in Logistic Systems via Reinforcement Learning](rbg.md)
-
-- **Paradigm:** Improvement
-- **Problems:** Large-scale Vehicle Routing Problem
-- **Venue:** KDD
-- **Year:** 2022
-- **First public:** 2022-08-12
-- **Institutions:** Tsinghua University; Beijing Tsingroc; Hitachi China Research and Development Corporation
 
 ### [Simulation-Guided Beam Search for Neural Combinatorial Optimization](simulation-guided-beam-search.md)
 
@@ -439,17 +475,9 @@ Select a paper title to open its research note.
 - **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem; Flexible Flow Shop Problem
 - **Venue:** NeurIPS
 - **Year:** 2022
-- **First public:** 2022-07-13
+- **Accepted:** [2022-09-14](https://neurips.cc/Conferences/2022/CallForPapers)
+- **arXiv:** [2022-07-13](https://arxiv.org/abs/2207.06190)
 - **Institutions:** Samsung SDS; Bielefeld University
-
-### [MAPDP: Cooperative Multi-Agent Reinforcement Learning to Solve Pickup and Delivery Problems](mapdp.md)
-
-- **Paradigm:** Constructive
-- **Problems:** Pickup and Delivery Problem
-- **Venue:** AAAI
-- **Year:** 2022
-- **First public:** 2022-06-28
-- **Institutions:** Tsinghua University; Hitachi China Research and Development Corporation
 
 ### [Diffusion Models as Plug-and-Play Priors](diffusion-plug-and-play-priors.md)
 
@@ -457,7 +485,8 @@ Select a paper title to open its research note.
 - **Problems:** Traveling Salesman Problem
 - **Venue:** NeurIPS
 - **Year:** 2022
-- **First public:** 2022-06-17
+- **Accepted:** [2022-09-14](https://neurips.cc/Conferences/2022/CallForPapers)
+- **arXiv:** [2022-06-17](https://arxiv.org/abs/2206.09012)
 - **Institutions:** Stony Brook University; Mila - Quebec AI Institute; Microsoft Research
 
 ### [Sym-NCO: Leveraging Symmetricity for Neural Combinatorial Optimization](sym-nco.md)
@@ -466,8 +495,19 @@ Select a paper title to open its research note.
 - **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem; Prize Collecting Traveling Salesman Problem; Orienteering Problem
 - **Venue:** NeurIPS
 - **Year:** 2022
-- **First public:** 2022-05-26
+- **Accepted:** [2022-09-14](https://neurips.cc/Conferences/2022/CallForPapers)
+- **arXiv:** [2022-05-26](https://arxiv.org/abs/2205.13209)
 - **Institutions:** Korea Advanced Institute of Science and Technology
+
+### [RBG: Hierarchically Solving Large-Scale Routing Problems in Logistic Systems via Reinforcement Learning](rbg.md)
+
+- **Paradigm:** Improvement
+- **Problems:** Large-scale Vehicle Routing Problem
+- **Venue:** KDD
+- **Year:** 2022
+- **Accepted:** [2022-05-18](https://kdd.org/kdd2022/cfpResearch.html)
+- **arXiv:** —
+- **Institutions:** Tsinghua University; Beijing Tsingroc; Hitachi China Research and Development Corporation
 
 ### [Pareto Set Learning for Neural Multi-Objective Combinatorial Optimization](pareto-set-learning.md)
 
@@ -475,44 +515,9 @@ Select a paper title to open its research note.
 - **Problems:** Bi-objective Traveling Salesman Problem; Tri-objective Traveling Salesman Problem; Multi-objective Capacitated Vehicle Routing Problem
 - **Venue:** ICLR
 - **Year:** 2022
-- **First public:** 2022-03-29
+- **Accepted:** [2022-01-24](https://iclr.cc/Conferences/2022/Dates)
+- **arXiv:** [2022-03-29](https://arxiv.org/abs/2203.15386)
 - **Institutions:** City University of Hong Kong; University of Essex
-
-### [Learning to Solve Routing Problems via Distributionally Robust Optimization](routing-dro.md)
-
-- **Paradigm:** Constructive
-- **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem
-- **Venue:** AAAI
-- **Year:** 2022
-- **First public:** 2022-02-15
-- **Institutions:** Nanyang Technological University; Singapore Institute of Manufacturing Technology
-
-### [Learning 3-opt Heuristics for Traveling Salesman Problem via Deep Reinforcement Learning](neural-3-opt.md)
-
-- **Paradigm:** Improvement
-- **Problems:** Traveling Salesman Problem
-- **Venue:** ACML
-- **Year:** 2021
-- **First public:** 2021-11-17
-- **Institutions:** Institute of Computing Technology; Chinese Academy of Sciences; University of Chinese Academy of Sciences; Zhongke Big Data Academy
-
-### [Learning Collaborative Policies to Solve NP-hard Routing Problems](learning-collaborative-policies.md)
-
-- **Paradigm:** Improvement
-- **Problems:** Traveling Salesman Problem; Prize Collecting Traveling Salesman Problem; Capacitated Vehicle Routing Problem
-- **Venue:** NeurIPS
-- **Year:** 2021
-- **First public:** 2021-10-26
-- **Institutions:** Korea Advanced Institute of Science and Technology
-
-### [NeuroLKH: Combining Deep Learning Model with Lin-Kernighan-Helsgaun Heuristic for Solving the Traveling Salesman Problem](neurolkh.md)
-
-- **Paradigm:** Improvement
-- **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem; Pickup and Delivery Problem; Vehicle Routing Problem with Time Windows
-- **Venue:** NeurIPS
-- **Year:** 2021
-- **First public:** 2021-10-15
-- **Institutions:** Nanyang Technological University; National University of Singapore; Shandong University
 
 ### [Graph Neural Network Guided Local Search for the Traveling Salesperson Problem](graph-guided-local-search.md)
 
@@ -520,35 +525,9 @@ Select a paper title to open its research note.
 - **Problems:** Traveling Salesman Problem
 - **Venue:** ICLR
 - **Year:** 2022
-- **First public:** 2021-10-12
+- **Accepted:** [2022-01-24](https://iclr.cc/Conferences/2022/Dates)
+- **arXiv:** [2021-10-11](https://arxiv.org/abs/2110.05291)
 - **Institutions:** University of Cambridge
-
-### [Learning to Iteratively Solve Routing Problems with Dual-Aspect Collaborative Transformer](dact.md)
-
-- **Paradigm:** Improvement
-- **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem
-- **Venue:** NeurIPS
-- **Year:** 2021
-- **First public:** 2021-10-06
-- **Institutions:** National University of Singapore; A*STAR; Shandong University; University of Electronic Science and Technology of China; Hong Kong University of Science and Technology
-
-### [Learning to Delegate for Large-Scale Vehicle Routing](learning-to-delegate.md)
-
-- **Paradigm:** Improvement
-- **Problems:** Capacitated Vehicle Routing Problem; Vehicle Routing Problem with Time Windows
-- **Venue:** NeurIPS
-- **Year:** 2021
-- **First public:** 2021-07-08
-- **Institutions:** Massachusetts Institute of Technology
-
-### [Matrix Encoding Networks for Neural Combinatorial Optimization](matrix-encoding-networks.md)
-
-- **Paradigm:** Constructive
-- **Problems:** Asymmetric Traveling Salesman Problem; Flexible Flow Shop Problem
-- **Venue:** NeurIPS
-- **Year:** 2021
-- **First public:** 2021-06-21
-- **Institutions:** Samsung SDS
 
 ### [Efficient Active Search for Combinatorial Optimization Problems](efficient-active-search.md)
 
@@ -556,7 +535,8 @@ Select a paper title to open its research note.
 - **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem; Orienteering Problem; Prize Collecting Traveling Salesman Problem; Flexible Flow Shop Problem
 - **Venue:** ICLR
 - **Year:** 2022
-- **First public:** 2021-06-09
+- **Accepted:** [2022-01-24](https://iclr.cc/Conferences/2022/Dates)
+- **arXiv:** [2021-06-09](https://arxiv.org/abs/2106.05126)
 - **Institutions:** Bielefeld University; Samsung SDS
 
 ### [Deep Policy Dynamic Programming for Vehicle Routing Problems](deep-policy-dynamic-programming.md)
@@ -565,8 +545,109 @@ Select a paper title to open its research note.
 - **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem; Vehicle Routing Problem with Time Windows
 - **Venue:** CPAIOR
 - **Year:** 2022
-- **First public:** 2021-02-23
+- **Accepted:** [2022](https://doi.org/10.1007/978-3-031-08011-1_14)
+- **arXiv:** [2021-02-23](https://arxiv.org/abs/2102.11756)
 - **Institutions:** University of Amsterdam; ORTEC
+
+### [MAPDP: Cooperative Multi-Agent Reinforcement Learning to Solve Pickup and Delivery Problems](mapdp.md)
+
+- **Paradigm:** Constructive
+- **Problems:** Pickup and Delivery Problem
+- **Venue:** AAAI
+- **Year:** 2022
+- **Accepted:** [2021-11-29](https://aaai.org/conference/aaai/aaai-22/)
+- **arXiv:** —
+- **Institutions:** Tsinghua University; Hitachi China Research and Development Corporation
+
+### [Learning to Solve Routing Problems via Distributionally Robust Optimization](routing-dro.md)
+
+- **Paradigm:** Constructive
+- **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem
+- **Venue:** AAAI
+- **Year:** 2022
+- **Accepted:** [2021-11-29](https://aaai.org/conference/aaai/aaai-22/)
+- **arXiv:** [2022-02-15](https://arxiv.org/abs/2202.07241)
+- **Institutions:** Nanyang Technological University; Singapore Institute of Manufacturing Technology
+
+### [Learning Collaborative Policies to Solve NP-hard Routing Problems](learning-collaborative-policies.md)
+
+- **Paradigm:** Improvement
+- **Problems:** Traveling Salesman Problem; Prize Collecting Traveling Salesman Problem; Capacitated Vehicle Routing Problem
+- **Venue:** NeurIPS
+- **Year:** 2021
+- **Accepted:** [2021-09-28](https://neurips.cc/Conferences/2021/CallForPapers)
+- **arXiv:** [2021-10-26](https://arxiv.org/abs/2110.13987)
+- **Institutions:** Korea Advanced Institute of Science and Technology
+
+### [NeuroLKH: Combining Deep Learning Model with Lin-Kernighan-Helsgaun Heuristic for Solving the Traveling Salesman Problem](neurolkh.md)
+
+- **Paradigm:** Improvement
+- **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem; Pickup and Delivery Problem; Vehicle Routing Problem with Time Windows
+- **Venue:** NeurIPS
+- **Year:** 2021
+- **Accepted:** [2021-09-28](https://neurips.cc/Conferences/2021/CallForPapers)
+- **arXiv:** [2021-10-15](https://arxiv.org/abs/2110.07983)
+- **Institutions:** Nanyang Technological University; National University of Singapore; Shandong University
+
+### [Learning to Iteratively Solve Routing Problems with Dual-Aspect Collaborative Transformer](dact.md)
+
+- **Paradigm:** Improvement
+- **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem
+- **Venue:** NeurIPS
+- **Year:** 2021
+- **Accepted:** [2021-09-28](https://neurips.cc/Conferences/2021/CallForPapers)
+- **arXiv:** [2021-10-06](https://arxiv.org/abs/2110.02544)
+- **Institutions:** National University of Singapore; A*STAR; Shandong University; University of Electronic Science and Technology of China; Hong Kong University of Science and Technology
+
+### [Learning to Delegate for Large-Scale Vehicle Routing](learning-to-delegate.md)
+
+- **Paradigm:** Improvement
+- **Problems:** Capacitated Vehicle Routing Problem; Vehicle Routing Problem with Time Windows
+- **Venue:** NeurIPS
+- **Year:** 2021
+- **Accepted:** [2021-09-28](https://neurips.cc/Conferences/2021/CallForPapers)
+- **arXiv:** [2021-07-08](https://arxiv.org/abs/2107.04139)
+- **Institutions:** Massachusetts Institute of Technology
+
+### [Matrix Encoding Networks for Neural Combinatorial Optimization](matrix-encoding-networks.md)
+
+- **Paradigm:** Constructive
+- **Problems:** Asymmetric Traveling Salesman Problem; Flexible Flow Shop Problem
+- **Venue:** NeurIPS
+- **Year:** 2021
+- **Accepted:** [2021-09-28](https://neurips.cc/Conferences/2021/CallForPapers)
+- **arXiv:** [2021-06-21](https://arxiv.org/abs/2106.11113)
+- **Institutions:** Samsung SDS
+
+### [Learning 3-opt Heuristics for Traveling Salesman Problem via Deep Reinforcement Learning](neural-3-opt.md)
+
+- **Paradigm:** Improvement
+- **Problems:** Traveling Salesman Problem
+- **Venue:** ACML
+- **Year:** 2021
+- **Accepted:** [2021-09-17](https://www.acml-conf.org/2021/)
+- **arXiv:** —
+- **Institutions:** Institute of Computing Technology; Chinese Academy of Sciences; University of Chinese Academy of Sciences; Zhongke Big Data Academy
+
+### [Learning a Latent Search Space for Routing Problems Using Variational Autoencoders](latent-search-space-routing.md)
+
+- **Paradigm:** Improvement
+- **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem
+- **Venue:** ICLR
+- **Year:** 2021
+- **Accepted:** [2021-01-14](https://iclr.cc/Conferences/2021/Dates)
+- **arXiv:** —
+- **Institutions:** Bielefeld University; University of Massachusetts Amherst
+
+### [Learning Improvement Heuristics for Solving Routing Problems](learning-improvement-heuristics.md)
+
+- **Paradigm:** Improvement
+- **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem
+- **Venue:** IEEE TNNLS
+- **Year:** 2022
+- **Accepted:** [2021](https://doi.org/10.1109/TNNLS.2021.3068828)
+- **arXiv:** [2019-12-12](https://arxiv.org/abs/1912.05784)
+- **Institutions:** Nanyang Technological University; National University of Singapore; Shandong University; Singapore Institute of Manufacturing Technology
 
 ### [Multi-Decoder Attention Model with Embedding Glimpse for Solving Vehicle Routing Problems](multi-decoder-attention-model.md)
 
@@ -574,7 +655,8 @@ Select a paper title to open its research note.
 - **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem
 - **Venue:** AAAI
 - **Year:** 2021
-- **First public:** 2020-12-18
+- **Accepted:** [2020-12-01](https://aaai.org/conference/aaai/aaai-21/)
+- **arXiv:** [2020-12-19](https://arxiv.org/abs/2012.10638)
 - **Institutions:** Nanyang Technological University; National University of Singapore; Shandong University
 
 ### [Generalize a Small Pre-trained Model to Arbitrarily Large TSP Instances](att-gcn.md)
@@ -583,7 +665,8 @@ Select a paper title to open its research note.
 - **Problems:** Traveling Salesman Problem
 - **Venue:** AAAI
 - **Year:** 2021
-- **First public:** 2020-11-26
+- **Accepted:** [2020-12-01](https://aaai.org/conference/aaai/aaai-21/)
+- **arXiv:** —
 - **Institutions:** The Chinese University of Hong Kong; Shenzhen
 
 ### [POMO: Policy Optimization with Multiple Optima for Reinforcement Learning](pomo.md)
@@ -592,35 +675,9 @@ Select a paper title to open its research note.
 - **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem
 - **Venue:** NeurIPS
 - **Year:** 2020
-- **First public:** 2020-10-30
+- **Accepted:** [2020-09-26](https://neurips.cc/Conferences/2020/Dates)
+- **arXiv:** [2020-10-30](https://arxiv.org/abs/2010.16011)
 - **Institutions:** Samsung SDS
-
-### [Step-Wise Deep Learning Models for Solving Routing Problems](step-wise-routing.md)
-
-- **Paradigm:** Constructive
-- **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem
-- **Venue:** IEEE TII
-- **Year:** 2021
-- **First public:** 2020-10-15
-- **Institutions:** Nanyang Technological University; National University of Singapore; Shandong University
-
-### [Learning a Latent Search Space for Routing Problems Using Variational Autoencoders](latent-search-space-routing.md)
-
-- **Paradigm:** Improvement
-- **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem
-- **Venue:** ICLR
-- **Year:** 2021
-- **First public:** 2020-09-25
-- **Institutions:** Bielefeld University; University of Massachusetts Amherst
-
-### [Efficiently Solving the Practical Vehicle Routing Problem: A Novel Joint Learning Approach](practical-vrp-joint-learning.md)
-
-- **Paradigm:** Constructive
-- **Problems:** Vehicle Routing Problem; Capacitated Vehicle Routing Problem
-- **Venue:** KDD
-- **Year:** 2020
-- **First public:** 2020-08-23
-- **Institutions:** Zhejiang Cainiao Supply Chain Management Co. Ltd; Alibaba Group
 
 ### [Learn to Design the Heuristics for Vehicle Routing Problem](egate.md)
 
@@ -628,26 +685,19 @@ Select a paper title to open its research note.
 - **Problems:** Capacitated Vehicle Routing Problem
 - **Venue:** IJCAI HSI Workshop
 - **Year:** 2020
-- **First public:** 2020-02-20
+- **Accepted:** [2020-05-20](https://groups.google.com/g/search-list/c/XmRwwEX9laY)
+- **arXiv:** [2020-02-20](https://arxiv.org/abs/2002.08539)
 - **Institutions:** Nanjing University of Aeronautics and Astronautics
 
-### [A Graph Neural Network Assisted Monte Carlo Tree Search Approach to Traveling Salesman Problem](gnn-mcts-tsp.md)
+### [Efficiently Solving the Practical Vehicle Routing Problem: A Novel Joint Learning Approach](practical-vrp-joint-learning.md)
 
 - **Paradigm:** Constructive
-- **Problems:** Traveling Salesman Problem
-- **Venue:** IEEE Access
+- **Problems:** Vehicle Routing Problem; Capacitated Vehicle Routing Problem
+- **Venue:** KDD
 - **Year:** 2020
-- **First public:** 2020-01-01
-- **Institutions:** Shanghai Jiao Tong University
-
-### [Learning Improvement Heuristics for Solving Routing Problems](learning-improvement-heuristics.md)
-
-- **Paradigm:** Improvement
-- **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem
-- **Venue:** IEEE TNNLS
-- **Year:** 2022
-- **First public:** 2019-12-12
-- **Institutions:** Nanyang Technological University; National University of Singapore; Shandong University; Singapore Institute of Manufacturing Technology
+- **Accepted:** [2020-05-15](https://www.kdd.org/kdd2020/calls/view/kdd-2020-call-for-research-papers.html)
+- **arXiv:** —
+- **Institutions:** Zhejiang Cainiao Supply Chain Management Co. Ltd; Alibaba Group
 
 ### [Neural Large Neighborhood Search for the Capacitated Vehicle Routing Problem](neural-large-neighborhood-search.md)
 
@@ -655,26 +705,29 @@ Select a paper title to open its research note.
 - **Problems:** Capacitated Vehicle Routing Problem
 - **Venue:** ECAI
 - **Year:** 2020
-- **First public:** 2019-11-21
+- **Accepted:** [2020-01-15](https://ecai2020.eu/call-for-papers/mainconference/)
+- **arXiv:** [2019-11-21](https://arxiv.org/abs/1911.09539)
 - **Institutions:** Bielefeld University
 
-### [A Deep Reinforcement Learning Algorithm Using Dynamic Attention Model for Vehicle Routing Problems](dynamic-am.md)
+### [Step-Wise Deep Learning Models for Solving Routing Problems](step-wise-routing.md)
 
 - **Paradigm:** Constructive
-- **Problems:** Capacitated Vehicle Routing Problem
-- **Venue:** ISICA
-- **Year:** 2019
-- **First public:** 2019-11-16
-- **Institutions:** Sun Yat-sen University
+- **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem
+- **Venue:** IEEE TII
+- **Year:** 2021
+- **Accepted:** [2020](https://doi.org/10.1109/TII.2020.3031409)
+- **arXiv:** —
+- **Institutions:** Nanyang Technological University; National University of Singapore; Shandong University
 
-### [Combinatorial Optimization by Graph Pointer Networks and Hierarchical Reinforcement Learning](graph-pointer-network-hrl.md)
+### [A Graph Neural Network Assisted Monte Carlo Tree Search Approach to Traveling Salesman Problem](gnn-mcts-tsp.md)
 
 - **Paradigm:** Constructive
-- **Problems:** Traveling Salesman Problem; Traveling Salesman Problem with Time Windows
-- **Venue:** AAAI Workshop on Deep Learning on Graphs: Methodologies and Applications
+- **Problems:** Traveling Salesman Problem
+- **Venue:** IEEE Access
 - **Year:** 2020
-- **First public:** 2019-11-12
-- **Institutions:** Columbia University; Cornell University
+- **Accepted:** [2020](https://doi.org/10.1109/ACCESS.2020.3000236)
+- **arXiv:** —
+- **Institutions:** Shanghai Jiao Tong University
 
 ### [A Learning-based Iterative Method for Solving Vehicle Routing Problems](learning-to-improve.md)
 
@@ -682,17 +735,19 @@ Select a paper title to open its research note.
 - **Problems:** Capacitated Vehicle Routing Problem; Split Delivery Vehicle Routing Problem
 - **Venue:** ICLR
 - **Year:** 2020
-- **First public:** 2019-09-25
+- **Accepted:** [2019-12-19](https://iclr.cc/Conferences/2020/Dates)
+- **arXiv:** —
 - **Institutions:** Ant Financial
 
-### [An Efficient Graph Convolutional Network Technique for the Travelling Salesman Problem](efficient-graph-convnet-tsp.md)
+### [Combinatorial Optimization by Graph Pointer Networks and Hierarchical Reinforcement Learning](graph-pointer-network-hrl.md)
 
 - **Paradigm:** Constructive
-- **Problems:** Traveling Salesman Problem
-- **Venue:** arXiv
-- **Year:** 2019
-- **First public:** 2019-06-04
-- **Institutions:** Nanyang Technological University; Loyola Marymount University
+- **Problems:** Traveling Salesman Problem; Traveling Salesman Problem with Time Windows
+- **Venue:** AAAI Workshop on Deep Learning on Graphs: Methodologies and Applications
+- **Year:** 2020
+- **Accepted:** [2019-12-06](https://deep-learning-graphs.bitbucket.io/dlg-aaai20/)
+- **arXiv:** [2019-11-12](https://arxiv.org/abs/1911.04936)
+- **Institutions:** Columbia University; Cornell University
 
 ### [Learning to Perform Local Rewriting for Combinatorial Optimization](neurewriter.md)
 
@@ -700,17 +755,29 @@ Select a paper title to open its research note.
 - **Problems:** Capacitated Vehicle Routing Problem; Job Shop Scheduling Problem
 - **Venue:** NeurIPS
 - **Year:** 2019
-- **First public:** 2018-09-30
+- **Accepted:** [2019-09-04](https://neurips.cc/Conferences/2019/Dates)
+- **arXiv:** [2018-09-30](https://arxiv.org/abs/1810.00337)
 - **Institutions:** Facebook AI Research; University of California, Berkeley
 
-### [Learning Heuristics for the TSP by Policy Gradient](learning-heuristic.md)
+### [An Efficient Graph Convolutional Network Technique for the Travelling Salesman Problem](efficient-graph-convnet-tsp.md)
 
 - **Paradigm:** Constructive
 - **Problems:** Traveling Salesman Problem
-- **Venue:** CPAIOR
-- **Year:** 2018
-- **First public:** 2018-06-26
-- **Institutions:** Polytechnique Montreal; Element AI; HEC Montreal; CIRRELT
+- **Venue:** arXiv
+- **Year:** 2019
+- **Accepted:** —
+- **arXiv:** [2019-06-04](https://arxiv.org/abs/1906.01227)
+- **Institutions:** Nanyang Technological University; Loyola Marymount University
+
+### [A Deep Reinforcement Learning Algorithm Using Dynamic Attention Model for Vehicle Routing Problems](dynamic-am.md)
+
+- **Paradigm:** Constructive
+- **Problems:** Capacitated Vehicle Routing Problem
+- **Venue:** ISICA
+- **Year:** 2019
+- **Accepted:** [2019](https://doi.org/10.1007/978-981-15-5577-0_51)
+- **arXiv:** [2020-02-09](https://arxiv.org/abs/2002.03282)
+- **Institutions:** Sun Yat-sen University
 
 ### [Attention, Learn to Solve Routing Problems!](attention-model.md)
 
@@ -718,7 +785,8 @@ Select a paper title to open its research note.
 - **Problems:** Traveling Salesman Problem; Capacitated Vehicle Routing Problem; Split Delivery Vehicle Routing Problem; Orienteering Problem; Prize Collecting Traveling Salesman Problem; Stochastic Prize Collecting Traveling Salesman Problem
 - **Venue:** ICLR
 - **Year:** 2019
-- **First public:** 2018-03-22
+- **Accepted:** [2018-12-22](https://iclr.cc/Conferences/2019/CallForPapers)
+- **arXiv:** [2018-03-22](https://arxiv.org/abs/1803.08475)
 - **Institutions:** University of Amsterdam; ORTEC; CIFAR
 
 ### [Reinforcement Learning for Solving the Vehicle Routing Problem](rl-vrp.md)
@@ -727,8 +795,19 @@ Select a paper title to open its research note.
 - **Problems:** Vehicle Routing Problem; Capacitated Vehicle Routing Problem
 - **Venue:** NeurIPS
 - **Year:** 2018
-- **First public:** 2018-02-12
+- **Accepted:** [2018-09-05](https://neurips.cc/Conferences/2018/Dates)
+- **arXiv:** [2018-02-12](https://arxiv.org/abs/1802.04240)
 - **Institutions:** Lehigh University
+
+### [Learning Heuristics for the TSP by Policy Gradient](learning-heuristic.md)
+
+- **Paradigm:** Constructive
+- **Problems:** Traveling Salesman Problem
+- **Venue:** CPAIOR
+- **Year:** 2018
+- **Accepted:** [2018](https://doi.org/10.1007/978-3-319-93031-2_12)
+- **arXiv:** —
+- **Institutions:** Polytechnique Montreal; Element AI; HEC Montreal; CIRRELT
 
 ### [Learning Combinatorial Optimization Algorithms over Graphs](learning-co-over-graphs.md)
 
@@ -736,7 +815,8 @@ Select a paper title to open its research note.
 - **Problems:** Minimum Vertex Cover; Maximum Cut; Traveling Salesman Problem
 - **Venue:** NIPS
 - **Year:** 2017
-- **First public:** 2017-04-05
+- **Accepted:** [2017-09-04](https://neurips.cc/Conferences/2017/Dates)
+- **arXiv:** [2017-04-05](https://arxiv.org/abs/1704.01665)
 - **Institutions:** Georgia Institute of Technology; Ant Financial
 
 ### [Neural Combinatorial Optimization with Reinforcement Learning](neural-combinatorial-optimization.md)
@@ -745,7 +825,8 @@ Select a paper title to open its research note.
 - **Problems:** Traveling Salesman Problem; Knapsack Problem
 - **Venue:** ICLR
 - **Year:** 2017
-- **First public:** 2016-11-29
+- **Accepted:** [2017-02-06](https://iclr.cc/archive/www/doku.php%3Fid%3Diclr2017%3Amain.html)
+- **arXiv:** [2016-11-29](https://arxiv.org/abs/1611.09940)
 - **Institutions:** Google Brain
 
 ### [Pointer Networks](pointer-networks.md)
@@ -754,7 +835,8 @@ Select a paper title to open its research note.
 - **Problems:** Traveling Salesman Problem; Convex Hull; Delaunay Triangulation
 - **Venue:** NeurIPS
 - **Year:** 2015
-- **First public:** 2015-06-10
+- **Accepted:** [2015](https://neurips.cc/Conferences/2015/Dates)
+- **arXiv:** [2015-06-09](https://arxiv.org/abs/1506.03134)
 - **Institutions:** Google Brain; University of California, Berkeley
 <!-- GENERATED_PAPER_INDEX_END -->
 

--- a/specialist/agfn.md
+++ b/specialist/agfn.md
@@ -8,7 +8,10 @@ authors:
   - "Zhiguang Cao"
   - "Xu Chi"
 year: 2025
-date: 2024-09-28
+date: 2025-03-03
+acceptance:
+  date: "2025-01-22"
+  source_url: "https://iclr.cc/Conferences/2025/Dates"
 venue: "ICLR"
 paper_url: "https://proceedings.iclr.cc/paper_files/paper/2025/hash/b210c387381713a14a4f5a607aff3520-Abstract-Conference.html"
 arxiv_url: "https://arxiv.org/abs/2503.01931"

--- a/specialist/asp.md
+++ b/specialist/asp.md
@@ -10,6 +10,9 @@ authors:
   - "Yaodong Yang"
 year: 2024
 date: 2023-03-01
+acceptance:
+  date: "2024"
+  source_url: "https://doi.org/10.1109/TPAMI.2024.3352096"
 venue: "IEEE TPAMI"
 paper_url: "https://doi.org/10.1109/TPAMI.2024.3352096"
 arxiv_url: "https://arxiv.org/abs/2303.00466"

--- a/specialist/att-gcn.md
+++ b/specialist/att-gcn.md
@@ -5,6 +5,9 @@ title: 'Generalize a Small Pre-trained Model to Arbitrarily Large TSP Instances'
 authors: [Zhang-Hua Fu, Kai-Bin Qiu, Hongyuan Zha]
 year: 2021
 date: 2020-11-26
+acceptance:
+  date: "2020-12-01"
+  source_url: "https://aaai.org/conference/aaai/aaai-21/"
 venue: AAAI
 paper_url: https://ojs.aaai.org/index.php/AAAI/article/view/16916
 code_url: https://github.com/Spider-scnu/TSP

--- a/specialist/attention-model.md
+++ b/specialist/attention-model.md
@@ -8,6 +8,9 @@ authors:
   - Max Welling
 year: 2019
 date: 2018-03-22
+acceptance:
+  date: "2018-12-22"
+  source_url: "https://iclr.cc/Conferences/2019/CallForPapers"
 venue: ICLR
 paper_url: https://openreview.net/forum?id=ByxBFsRqYm
 arxiv_url: https://arxiv.org/abs/1803.08475

--- a/specialist/bq-nco.md
+++ b/specialist/bq-nco.md
@@ -10,6 +10,9 @@ authors:
   - "Jean-Marc Andreoli"
 year: 2023
 date: 2023-01-09
+acceptance:
+  date: "2023-09-21"
+  source_url: "https://neurips.cc/Conferences/2023/CallForPapers"
 venue: "NeurIPS"
 paper_url: "https://proceedings.neurips.cc/paper_files/paper/2023/hash/f445ba15f0f05c26e1d24f908ea78d60-Abstract-Conference.html"
 arxiv_url: "https://arxiv.org/abs/2301.03313"

--- a/specialist/compass.md
+++ b/specialist/compass.md
@@ -12,6 +12,9 @@ authors:
   - "Thomas D. Barrett"
 year: 2023
 date: 2023-11-13
+acceptance:
+  date: "2023-09-21"
+  source_url: "https://neurips.cc/Conferences/2023/CallForPapers"
 venue: "NeurIPS"
 paper_url: "https://proceedings.neurips.cc/paper_files/paper/2023/hash/18d3a2f3068d6c669dcae19ceca1bc24-Abstract-Conference.html"
 arxiv_url: "https://arxiv.org/abs/2311.13569"

--- a/specialist/constraint-tightness.md
+++ b/specialist/constraint-tightness.md
@@ -9,6 +9,9 @@ authors:
   - "Zhenkun Wang"
 year: 2025
 date: 2025-05-30
+acceptance:
+  date: "2025-09-18"
+  source_url: "https://neurips.cc/Conferences/2025/CallForPapers"
 venue: "NeurIPS"
 paper_url: "https://proceedings.neurips.cc/paper_files/paper/2025/hash/b8fc784104e74f1b427865d30ad22931-Abstract-Conference.html"
 code_url: "https://github.com/CIAM-Group/Rethinking_Constraint_Tightness"

--- a/specialist/dact.md
+++ b/specialist/dact.md
@@ -12,6 +12,9 @@ authors:
   - Jing Tang
 year: 2021
 date: 2021-10-06
+acceptance:
+  date: "2021-09-28"
+  source_url: "https://neurips.cc/Conferences/2021/CallForPapers"
 venue: NeurIPS
 paper_url: https://proceedings.neurips.cc/paper/2021/hash/5c53292c032b6cb8510041c54274e65f-Abstract.html
 arxiv_url: https://arxiv.org/abs/2110.02544

--- a/specialist/dar.md
+++ b/specialist/dar.md
@@ -9,6 +9,9 @@ authors:
   - "Yi Mei"
 year: 2025
 date: 2023-11-01
+acceptance:
+  date: "2025"
+  source_url: "https://doi.org/10.1109/TNNLS.2025.3588209"
 venue: "IEEE TNNLS"
 paper_url: "https://doi.org/10.1109/TNNLS.2025.3588209"
 institutions:

--- a/specialist/deep-policy-dynamic-programming.md
+++ b/specialist/deep-policy-dynamic-programming.md
@@ -5,6 +5,9 @@ title: 'Deep Policy Dynamic Programming for Vehicle Routing Problems'
 authors: [Wouter Kool, Herke van Hoof, Joaquim Gromicho, Max Welling]
 year: 2022
 date: 2021-02-23
+acceptance:
+  date: "2022"
+  source_url: "https://doi.org/10.1007/978-3-031-08011-1_14"
 venue: CPAIOR
 paper_url: https://doi.org/10.1007/978-3-031-08011-1_14
 arxiv_url: https://arxiv.org/abs/2102.11756

--- a/specialist/deepaco.md
+++ b/specialist/deepaco.md
@@ -10,6 +10,9 @@ authors:
   - Yong Li
 year: 2023
 date: 2023-09-25
+acceptance:
+  date: "2023-09-21"
+  source_url: "https://neurips.cc/Conferences/2023/CallForPapers"
 venue: NeurIPS
 paper_url: https://proceedings.neurips.cc/paper_files/paper/2023/hash/883105b282fe15275991b411e6b200c5-Abstract-Conference.html
 arxiv_url: https://arxiv.org/abs/2309.14032

--- a/specialist/dgl.md
+++ b/specialist/dgl.md
@@ -14,6 +14,9 @@ authors:
   - "Ying Jiang"
 year: 2025
 date: 2025-01-15
+acceptance:
+  date: "2025-04-28"
+  source_url: "https://2025.ijcai.org/important-dates/"
 venue: "IJCAI"
 paper_url: "https://www.ijcai.org/proceedings/2025/964"
 code_url: "https://github.com/wuyuesong/DGL"

--- a/specialist/diffusion-plug-and-play-priors.md
+++ b/specialist/diffusion-plug-and-play-priors.md
@@ -5,6 +5,9 @@ title: 'Diffusion Models as Plug-and-Play Priors'
 authors: [Alexandros Graikos, Nikolay Malkin, Nebojsa Jojic, Dimitris Samaras]
 year: 2022
 date: 2022-06-17
+acceptance:
+  date: "2022-09-14"
+  source_url: "https://neurips.cc/Conferences/2022/CallForPapers"
 venue: NeurIPS
 paper_url: https://proceedings.neurips.cc/paper_files/paper/2022/hash/5e6cec2a9520708381fe520246018e8b-Abstract.html
 arxiv_url: https://arxiv.org/abs/2206.09012

--- a/specialist/difusco.md
+++ b/specialist/difusco.md
@@ -7,6 +7,9 @@ authors:
   - "Yiming Yang"
 year: 2023
 date: 2023-02-16
+acceptance:
+  date: "2023-09-21"
+  source_url: "https://neurips.cc/Conferences/2023/CallForPapers"
 venue: "NeurIPS"
 paper_url: "https://proceedings.neurips.cc/paper_files/paper/2023/hash/0ba520d93c3df592c83a611961314c98-Abstract-Conference.html"
 arxiv_url: "https://arxiv.org/abs/2302.08224"

--- a/specialist/dimes.md
+++ b/specialist/dimes.md
@@ -5,6 +5,9 @@ title: 'DIMES: A Differentiable Meta Solver for Combinatorial Optimization Probl
 authors: [Ruizhong Qiu, Zhiqing Sun, Yiming Yang]
 year: 2022
 date: 2022-10-08
+acceptance:
+  date: "2022-09-14"
+  source_url: "https://neurips.cc/Conferences/2022/CallForPapers"
 venue: NeurIPS
 paper_url: https://proceedings.neurips.cc/paper_files/paper/2022/hash/a3a7387e49f4de290c23beea2dfcdc75-Abstract-Conference.html
 arxiv_url: https://arxiv.org/abs/2210.04123

--- a/specialist/dpn.md
+++ b/specialist/dpn.md
@@ -11,6 +11,9 @@ authors:
   - "Ke Tang"
 year: 2024
 date: 2024-05-27
+acceptance:
+  date: "2024-05-01"
+  source_url: "https://icml.cc/Conferences/2024/Dates"
 venue: "ICML"
 paper_url: "https://proceedings.mlr.press/v235/zheng24m.html"
 arxiv_url: "https://arxiv.org/abs/2405.17272"

--- a/specialist/drhg.md
+++ b/specialist/drhg.md
@@ -9,6 +9,9 @@ authors:
   - "Qingfu Zhang"
 year: 2025
 date: 2025-02-22
+acceptance:
+  date: "2024-12-09"
+  source_url: "https://aaai.org/conference/aaai/aaai-25/"
 venue: "AAAI"
 paper_url: "https://ojs.aaai.org/index.php/AAAI/article/view/34018"
 arxiv_url: "https://arxiv.org/abs/2502.16170"

--- a/specialist/dynamic-am.md
+++ b/specialist/dynamic-am.md
@@ -7,7 +7,10 @@ authors:
   - Jiahai Wang
   - Zizhen Zhang
 year: 2019
-date: 2019-11-16
+date: 2020-02-09
+acceptance:
+  date: "2019"
+  source_url: "https://doi.org/10.1007/978-981-15-5577-0_51"
 venue: ISICA
 paper_url: https://doi.org/10.1007/978-981-15-5577-0_51
 arxiv_url: https://arxiv.org/abs/2002.03282

--- a/specialist/efficient-active-search.md
+++ b/specialist/efficient-active-search.md
@@ -5,6 +5,9 @@ title: 'Efficient Active Search for Combinatorial Optimization Problems'
 authors: [André Hottung, Yeong-Dae Kwon, Kevin Tierney]
 year: 2022
 date: 2021-06-09
+acceptance:
+  date: "2022-01-24"
+  source_url: "https://iclr.cc/Conferences/2022/Dates"
 venue: ICLR
 paper_url: https://openreview.net/forum?id=nO5caZwFwYu
 arxiv_url: https://arxiv.org/abs/2106.05126

--- a/specialist/egate.md
+++ b/specialist/egate.md
@@ -11,6 +11,9 @@ authors:
   - Zhixin Liu
 year: 2020
 date: 2020-02-20
+acceptance:
+  date: "2020-05-20"
+  source_url: "https://groups.google.com/g/search-list/c/XmRwwEX9laY"
 venue: IJCAI HSI Workshop
 paper_url: https://hsi-workshop.github.io/hsi2020-website/hsi2020/Learn%20to%20Design%20the%20Heuristics%20for%20Vehicle%20Routing%20Problem.pdf
 arxiv_url: https://arxiv.org/abs/2002.08539

--- a/specialist/elg.md
+++ b/specialist/elg.md
@@ -10,6 +10,9 @@ authors:
   - "Chao Qian"
 year: 2024
 date: 2024-04-11
+acceptance:
+  date: "2024-04-16"
+  source_url: "https://ijcai24.org/call-for-papers/index.html"
 venue: "IJCAI"
 paper_url: "https://www.ijcai.org/proceedings/2024/0764"
 code_url: "https://github.com/gaocrr/ELG"

--- a/specialist/fast-t2t.md
+++ b/specialist/fast-t2t.md
@@ -9,7 +9,10 @@ authors:
   - "Hongyuan Zha"
   - "Junchi Yan"
 year: 2024
-date: 2024-12-09
+date: 2025-02-05
+acceptance:
+  date: "2024-09-25"
+  source_url: "https://neurips.cc/Conferences/2024/CallForPapers"
 venue: "NeurIPS"
 paper_url: "https://proceedings.neurips.cc/paper_files/paper/2024/hash/352b13f01566ae34affacc60e98c16af-Abstract-Conference.html"
 arxiv_url: "https://arxiv.org/abs/2502.02941"

--- a/specialist/fer.md
+++ b/specialist/fer.md
@@ -12,6 +12,9 @@ authors:
   - "Yeow Meng Chee"
 year: 2024
 date: 2023-06-15
+acceptance:
+  date: "2023"
+  source_url: "https://doi.org/10.1109/TNNLS.2023.3285077"
 venue: "IEEE TNNLS"
 paper_url: "https://doi.org/10.1109/TNNLS.2023.3285077"
 institutions:

--- a/specialist/gensco.md
+++ b/specialist/gensco.md
@@ -10,6 +10,9 @@ authors:
   - "Junchi Yan"
 year: 2025
 date: 2025-05-23
+acceptance:
+  date: "2025-09-18"
+  source_url: "https://neurips.cc/Conferences/2025/CallForPapers"
 venue: "NeurIPS"
 paper_url: "https://proceedings.neurips.cc/paper_files/paper/2025/hash/b8e9869fa827226ff68db9290659a20c-Abstract-Conference.html"
 code_url: "https://github.com/Thinklab-SJTU/GenSCO"

--- a/specialist/gfacs.md
+++ b/specialist/gfacs.md
@@ -11,6 +11,9 @@ authors:
   - "Yoshua Bengio"
 year: 2025
 date: 2024-03-11
+acceptance:
+  date: "2025-01-21"
+  source_url: "https://aistats.org/aistats2025/dates.html"
 venue: "AISTATS"
 paper_url: "https://proceedings.mlr.press/v258/kim25a.html"
 arxiv_url: "https://arxiv.org/abs/2403.07041"

--- a/specialist/glop.md
+++ b/specialist/glop.md
@@ -11,6 +11,9 @@ authors:
   - "Fanzhang Li"
 year: 2024
 date: 2023-12-13
+acceptance:
+  date: "2023-12-09"
+  source_url: "https://aaai.org/conference/aaai/aaai-24/"
 venue: "AAAI"
 paper_url: "https://ojs.aaai.org/index.php/AAAI/article/view/30009"
 arxiv_url: "https://arxiv.org/abs/2312.08224"

--- a/specialist/gnn-mcts-tsp.md
+++ b/specialist/gnn-mcts-tsp.md
@@ -7,6 +7,9 @@ authors:
   - Shikui Tu
 year: 2020
 date: 2020-01-01
+acceptance:
+  date: "2020"
+  source_url: "https://doi.org/10.1109/ACCESS.2020.3000236"
 venue: IEEE Access
 paper_url: https://doi.org/10.1109/ACCESS.2020.3000236
 institutions:

--- a/specialist/graph-guided-local-search.md
+++ b/specialist/graph-guided-local-search.md
@@ -4,7 +4,10 @@ short_title: RGLS
 title: 'Graph Neural Network Guided Local Search for the Traveling Salesperson Problem'
 authors: [Benjamin Hudson, Qingbiao Li, Matthew Malencia, Amanda Prorok]
 year: 2022
-date: 2021-10-12
+date: 2021-10-11
+acceptance:
+  date: "2022-01-24"
+  source_url: "https://iclr.cc/Conferences/2022/Dates"
 venue: ICLR
 paper_url: https://openreview.net/forum?id=ar92oEosBIg
 arxiv_url: https://arxiv.org/abs/2110.05291

--- a/specialist/graph-pointer-network-hrl.md
+++ b/specialist/graph-pointer-network-hrl.md
@@ -10,6 +10,9 @@ authors:
   - Iddo Drori
 year: 2020
 date: 2019-11-12
+acceptance:
+  date: "2019-12-06"
+  source_url: "https://deep-learning-graphs.bitbucket.io/dlg-aaai20/"
 venue: 'AAAI Workshop on Deep Learning on Graphs: Methodologies and Applications'
 paper_url: https://arxiv.org/abs/1911.04936
 arxiv_url: https://arxiv.org/abs/1911.04936

--- a/specialist/gumbeldore.md
+++ b/specialist/gumbeldore.md
@@ -7,6 +7,9 @@ authors:
   - "Dominik G. Grimm"
 year: 2024
 date: 2024-03-22
+acceptance:
+  date: "2024-06"
+  source_url: "https://openreview.net/forum?id=agT8ojoH0X"
 venue: "TMLR"
 paper_url: "https://openreview.net/forum?id=agT8ojoH0X"
 arxiv_url: "https://arxiv.org/abs/2403.15180"

--- a/specialist/h-tsp.md
+++ b/specialist/h-tsp.md
@@ -12,6 +12,9 @@ authors:
   - "Jiang Bian"
 year: 2023
 date: 2023-04-19
+acceptance:
+  date: "2022-11-18"
+  source_url: "https://aaai-23.aaai.org/aaai23call/"
 venue: "AAAI"
 paper_url: "https://ojs.aaai.org/index.php/AAAI/article/view/26120"
 arxiv_url: "https://arxiv.org/abs/2304.09395"

--- a/specialist/hncs.md
+++ b/specialist/hncs.md
@@ -11,6 +11,9 @@ authors:
   - "Wee Sun Lee"
 year: 2024
 date: 2024-08-07
+acceptance:
+  date: "2024-05-16"
+  source_url: "https://www.kdd.org/kdd2024/research-track-call-for-papers/"
 venue: "KDD"
 paper_url: "https://doi.org/10.1145/3637528.3672053"
 arxiv_url: "https://arxiv.org/abs/2408.03585"

--- a/specialist/icam.md
+++ b/specialist/icam.md
@@ -11,6 +11,9 @@ authors:
   - "Qingfu Zhang"
 year: 2026
 date: 2024-05-03
+acceptance:
+  date: "2026"
+  source_url: "https://doi.org/10.1109/TITS.2026.3674538"
 venue: "IEEE T-ITS"
 paper_url: "https://doi.org/10.1109/TITS.2026.3674538"
 arxiv_url: "https://arxiv.org/abs/2405.01906"

--- a/specialist/invit.md
+++ b/specialist/invit.md
@@ -9,6 +9,9 @@ authors:
   - "Yutong Ban"
 year: 2024
 date: 2024-02-04
+acceptance:
+  date: "2024-05-01"
+  source_url: "https://icml.cc/Conferences/2024/Dates"
 venue: "ICML"
 paper_url: "https://proceedings.mlr.press/v235/fang24c.html"
 arxiv_url: "https://arxiv.org/abs/2402.02317"

--- a/specialist/l2c-insert.md
+++ b/specialist/l2c-insert.md
@@ -12,6 +12,9 @@ authors:
   - "Qingfu Zhang"
 year: 2025
 date: 2025-05-20
+acceptance:
+  date: "2025-09-18"
+  source_url: "https://neurips.cc/Conferences/2025/CallForPapers"
 venue: "NeurIPS"
 paper_url: "https://proceedings.neurips.cc/paper_files/paper/2025/hash/7e3192a54b4ce5855a90dc182eac2036-Abstract-Conference.html"
 arxiv_url: "https://arxiv.org/abs/2505.13904"

--- a/specialist/l2r.md
+++ b/specialist/l2r.md
@@ -9,6 +9,9 @@ authors:
   - "Qingfu Zhang"
 year: 2026
 date: 2025-03-05
+acceptance:
+  date: "2025-11-23"
+  source_url: "https://kdd2026.kdd.org/research-track-call-for-papers/"
 venue: "KDD"
 paper_url: "https://doi.org/10.1145/3770855.3818173"
 arxiv_url: "https://arxiv.org/abs/2503.03137"

--- a/specialist/l2seg.md
+++ b/specialist/l2seg.md
@@ -9,6 +9,9 @@ authors:
   - "Cathy Wu"
 year: 2026
 date: 2025-06-22
+acceptance:
+  date: "2026-01-25"
+  source_url: "https://iclr.cc/Conferences/2026/Dates"
 venue: "ICLR"
 paper_url: "https://proceedings.iclr.cc/paper_files/paper/2026/hash/f274af80a7a3aa9ed23ba6f7908470bc-Abstract-Conference.html"
 arxiv_url: "https://arxiv.org/abs/2507.01037"

--- a/specialist/latent-search-space-routing.md
+++ b/specialist/latent-search-space-routing.md
@@ -5,6 +5,9 @@ title: 'Learning a Latent Search Space for Routing Problems Using Variational Au
 authors: [André Hottung, Bhanu Bhandari, Kevin Tierney]
 year: 2021
 date: 2020-09-25
+acceptance:
+  date: "2021-01-14"
+  source_url: "https://iclr.cc/Conferences/2021/Dates"
 venue: ICLR
 paper_url: https://openreview.net/forum?id=90JprVrJBO
 code_url: https://github.com/ahottung/learning-a-latent-search-space

--- a/specialist/learning-co-over-graphs.md
+++ b/specialist/learning-co-over-graphs.md
@@ -10,6 +10,9 @@ authors:
   - Le Song
 year: 2017
 date: 2017-04-05
+acceptance:
+  date: "2017-09-04"
+  source_url: "https://neurips.cc/Conferences/2017/Dates"
 venue: NIPS
 paper_url: https://papers.nips.cc/paper_files/paper/2017/hash/d9896106ca98d3d05b8cbdf4fd8b13a1-Abstract.html
 arxiv_url: https://arxiv.org/abs/1704.01665

--- a/specialist/learning-collaborative-policies.md
+++ b/specialist/learning-collaborative-policies.md
@@ -5,6 +5,9 @@ title: 'Learning Collaborative Policies to Solve NP-hard Routing Problems'
 authors: [Minsu Kim, Jinkyoo Park, Joungho Kim]
 year: 2021
 date: 2021-10-26
+acceptance:
+  date: "2021-09-28"
+  source_url: "https://neurips.cc/Conferences/2021/CallForPapers"
 venue: NeurIPS
 paper_url: https://proceedings.neurips.cc/paper/2021/hash/564127c03caab942e503ee6f810f54fd-Abstract.html
 arxiv_url: https://arxiv.org/abs/2110.13987

--- a/specialist/learning-heuristic.md
+++ b/specialist/learning-heuristic.md
@@ -10,6 +10,9 @@ authors:
   - Louis-Martin Rousseau
 year: 2018
 date: 2018-06-26
+acceptance:
+  date: "2018"
+  source_url: "https://doi.org/10.1007/978-3-319-93031-2_12"
 venue: CPAIOR
 paper_url: https://doi.org/10.1007/978-3-319-93031-2_12
 code_url: https://github.com/MichelDeudon/encode-attend-navigate

--- a/specialist/learning-improvement-heuristics.md
+++ b/specialist/learning-improvement-heuristics.md
@@ -5,6 +5,9 @@ title: 'Learning Improvement Heuristics for Solving Routing Problems'
 authors: [Yaoxin Wu, Wen Song, Zhiguang Cao, Jie Zhang, Andrew Lim]
 year: 2022
 date: 2019-12-12
+acceptance:
+  date: "2021"
+  source_url: "https://doi.org/10.1109/TNNLS.2021.3068828"
 venue: IEEE TNNLS
 paper_url: https://doi.org/10.1109/TNNLS.2021.3068828
 arxiv_url: https://arxiv.org/abs/1912.05784

--- a/specialist/learning-to-delegate.md
+++ b/specialist/learning-to-delegate.md
@@ -5,6 +5,9 @@ title: 'Learning to Delegate for Large-Scale Vehicle Routing'
 authors: [Sirui Li, Zhongxia Yan, Cathy Wu]
 year: 2021
 date: 2021-07-08
+acceptance:
+  date: "2021-09-28"
+  source_url: "https://neurips.cc/Conferences/2021/CallForPapers"
 venue: NeurIPS
 paper_url: https://proceedings.neurips.cc/paper/2021/hash/dc9fa5f217a1e57b8a6adeb065560b38-Abstract.html
 arxiv_url: https://arxiv.org/abs/2107.04139

--- a/specialist/learning-to-improve.md
+++ b/specialist/learning-to-improve.md
@@ -8,6 +8,9 @@ authors:
   - Shuang Yang
 year: 2020
 date: 2019-09-25
+acceptance:
+  date: "2019-12-19"
+  source_url: "https://iclr.cc/Conferences/2020/Dates"
 venue: ICLR
 paper_url: https://openreview.net/forum?id=BJe1334YDH
 code_url: https://github.com/rlopt/l2i

--- a/specialist/lehd.md
+++ b/specialist/lehd.md
@@ -10,6 +10,9 @@ authors:
   - "Zhenkun Wang"
 year: 2023
 date: 2023-10-12
+acceptance:
+  date: "2023-09-21"
+  source_url: "https://neurips.cc/Conferences/2023/CallForPapers"
 venue: "NeurIPS"
 paper_url: "https://proceedings.neurips.cc/paper_files/paper/2023/hash/1c10d0c087c14689628124bbc8fa69f6-Abstract-Conference.html"
 arxiv_url: "https://arxiv.org/abs/2310.07985"

--- a/specialist/mapdp.md
+++ b/specialist/mapdp.md
@@ -5,6 +5,9 @@ title: 'MAPDP: Cooperative Multi-Agent Reinforcement Learning to Solve Pickup an
 authors: [Zefang Zong, Meng Zheng, Yong Li, Depeng Jin]
 year: 2022
 date: 2022-06-28
+acceptance:
+  date: "2021-11-29"
+  source_url: "https://aaai.org/conference/aaai/aaai-22/"
 venue: AAAI
 paper_url: https://ojs.aaai.org/index.php/AAAI/article/view/21236
 institutions: [Tsinghua University, Hitachi China Research and Development Corporation]

--- a/specialist/matrix-encoding-networks.md
+++ b/specialist/matrix-encoding-networks.md
@@ -5,6 +5,9 @@ title: 'Matrix Encoding Networks for Neural Combinatorial Optimization'
 authors: [Yeong-Dae Kwon, Jinho Choo, Iljoo Yoon, Minah Park, Duwon Park, Youngjune Gwon]
 year: 2021
 date: 2021-06-21
+acceptance:
+  date: "2021-09-28"
+  source_url: "https://neurips.cc/Conferences/2021/CallForPapers"
 venue: NeurIPS
 paper_url: https://proceedings.neurips.cc/paper/2021/hash/29539ed932d32f1c56324cded92c07c2-Abstract.html
 arxiv_url: https://arxiv.org/abs/2106.11113

--- a/specialist/meta-sage.md
+++ b/specialist/meta-sage.md
@@ -9,6 +9,9 @@ authors:
   - "Jinkyoo Park"
 year: 2023
 date: 2023-06-05
+acceptance:
+  date: "2023-04-24"
+  source_url: "https://icml.cc/Conferences/2023/Dates"
 venue: "ICML"
 paper_url: "https://proceedings.mlr.press/v202/son23a.html"
 arxiv_url: "https://arxiv.org/abs/2306.02688"

--- a/specialist/multi-decoder-attention-model.md
+++ b/specialist/multi-decoder-attention-model.md
@@ -4,7 +4,10 @@ short_title: MDAM
 title: 'Multi-Decoder Attention Model with Embedding Glimpse for Solving Vehicle Routing Problems'
 authors: [Liang Xin, Wen Song, Zhiguang Cao, Jie Zhang]
 year: 2021
-date: 2020-12-18
+date: 2020-12-19
+acceptance:
+  date: "2020-12-01"
+  source_url: "https://aaai.org/conference/aaai/aaai-21/"
 venue: AAAI
 paper_url: https://ojs.aaai.org/index.php/AAAI/article/view/17430
 arxiv_url: https://arxiv.org/abs/2012.10638

--- a/specialist/ncs.md
+++ b/specialist/ncs.md
@@ -10,6 +10,9 @@ authors:
   - "Jianhua Xiao"
 year: 2024
 date: 2023-08-01
+acceptance:
+  date: "2024"
+  source_url: "https://doi.org/10.1109/TPAMI.2024.3450850"
 venue: "IEEE TPAMI"
 paper_url: "https://doi.org/10.1109/TPAMI.2024.3450850"
 institutions:

--- a/specialist/nds.md
+++ b/specialist/nds.md
@@ -8,6 +8,9 @@ authors:
   - "Kevin Tierney"
 year: 2025
 date: 2025-01-07
+acceptance:
+  date: "2025-05-05"
+  source_url: "https://openreview.net/forum?id=bCmEP1Ltwq"
 venue: "TMLR"
 paper_url: "https://openreview.net/forum?id=bCmEP1Ltwq"
 arxiv_url: "https://arxiv.org/abs/2501.03715"

--- a/specialist/neuopt.md
+++ b/specialist/neuopt.md
@@ -8,6 +8,9 @@ authors:
   - "Yeow Meng Chee"
 year: 2023
 date: 2023-10-27
+acceptance:
+  date: "2023-09-21"
+  source_url: "https://neurips.cc/Conferences/2023/CallForPapers"
 venue: "NeurIPS"
 paper_url: "https://proceedings.neurips.cc/paper_files/paper/2023/hash/9bae70d354793a95fa18751888cea07d-Abstract-Conference.html"
 arxiv_url: "https://arxiv.org/abs/2310.18264"

--- a/specialist/neural-3-opt.md
+++ b/specialist/neural-3-opt.md
@@ -5,6 +5,9 @@ title: 'Learning 3-opt Heuristics for Traveling Salesman Problem via Deep Reinfo
 authors: [Jingyan Sui, Shizhe Ding, Ruizhi Liu, Liming Xu, Dongbo Bu]
 year: 2021
 date: 2021-11-17
+acceptance:
+  date: "2021-09-17"
+  source_url: "https://www.acml-conf.org/2021/"
 venue: ACML
 paper_url: https://proceedings.mlr.press/v157/sui21a.html
 institutions: [Institute of Computing Technology, Chinese Academy of Sciences, University of Chinese Academy of Sciences, Zhongke Big Data Academy]

--- a/specialist/neural-combinatorial-optimization.md
+++ b/specialist/neural-combinatorial-optimization.md
@@ -10,6 +10,9 @@ authors:
   - Samy Bengio
 year: 2017
 date: 2016-11-29
+acceptance:
+  date: "2017-02-06"
+  source_url: "https://iclr.cc/archive/www/doku.php%3Fid%3Diclr2017%3Amain.html"
 venue: ICLR
 paper_url: https://arxiv.org/abs/1611.09940
 arxiv_url: https://arxiv.org/abs/1611.09940

--- a/specialist/neural-large-neighborhood-search.md
+++ b/specialist/neural-large-neighborhood-search.md
@@ -7,6 +7,9 @@ authors:
   - Kevin Tierney
 year: 2020
 date: 2019-11-21
+acceptance:
+  date: "2020-01-15"
+  source_url: "https://ecai2020.eu/call-for-papers/mainconference/"
 venue: ECAI
 paper_url: https://ebooks.iospress.nl/doi/10.3233/FAIA200283
 arxiv_url: https://arxiv.org/abs/1911.09539

--- a/specialist/neurewriter.md
+++ b/specialist/neurewriter.md
@@ -7,6 +7,9 @@ authors:
   - Yuandong Tian
 year: 2019
 date: 2018-09-30
+acceptance:
+  date: "2019-09-04"
+  source_url: "https://neurips.cc/Conferences/2019/Dates"
 venue: NeurIPS
 paper_url: https://proceedings.neurips.cc/paper/2019/hash/131f383b434fdf48079bff1e44e2d9a5-Abstract.html
 arxiv_url: https://arxiv.org/abs/1810.00337

--- a/specialist/neurolkh.md
+++ b/specialist/neurolkh.md
@@ -5,6 +5,9 @@ title: 'NeuroLKH: Combining Deep Learning Model with Lin-Kernighan-Helsgaun Heur
 authors: [Liang Xin, Wen Song, Zhiguang Cao, Jie Zhang]
 year: 2021
 date: 2021-10-15
+acceptance:
+  date: "2021-09-28"
+  source_url: "https://neurips.cc/Conferences/2021/CallForPapers"
 venue: NeurIPS
 paper_url: https://proceedings.neurips.cc/paper/2021/hash/3d863b367aa379f71c7afc0c9cdca41d-Abstract.html
 arxiv_url: https://arxiv.org/abs/2110.07983

--- a/specialist/omni-vrp.md
+++ b/specialist/omni-vrp.md
@@ -10,6 +10,9 @@ authors:
   - "Jie Zhang"
 year: 2023
 date: 2023-05-31
+acceptance:
+  date: "2023-04-24"
+  source_url: "https://icml.cc/Conferences/2023/Dates"
 venue: "ICML"
 paper_url: "https://proceedings.mlr.press/v202/zhou23o.html"
 arxiv_url: "https://arxiv.org/abs/2305.19587"

--- a/specialist/pareto-set-learning.md
+++ b/specialist/pareto-set-learning.md
@@ -5,6 +5,9 @@ title: 'Pareto Set Learning for Neural Multi-Objective Combinatorial Optimizatio
 authors: [Xi Lin, Zhiyuan Yang, Qingfu Zhang]
 year: 2022
 date: 2022-03-29
+acceptance:
+  date: "2022-01-24"
+  source_url: "https://iclr.cc/Conferences/2022/Dates"
 venue: ICLR
 paper_url: https://openreview.net/forum?id=QuObT9BTWo
 arxiv_url: https://arxiv.org/abs/2203.15386

--- a/specialist/pip.md
+++ b/specialist/pip.md
@@ -12,6 +12,9 @@ authors:
   - "Jie Zhang"
 year: 2024
 date: 2024-10-28
+acceptance:
+  date: "2024-09-25"
+  source_url: "https://neurips.cc/Conferences/2024/CallForPapers"
 venue: "NeurIPS"
 paper_url: "https://proceedings.neurips.cc/paper_files/paper/2024/hash/a9d2a5fd12d34250c21b5e4fa8d906b0-Abstract-Conference.html"
 arxiv_url: "https://arxiv.org/abs/2410.21066"

--- a/specialist/pointer-networks.md
+++ b/specialist/pointer-networks.md
@@ -7,7 +7,10 @@ authors:
   - Meire Fortunato
   - Navdeep Jaitly
 year: 2015
-date: 2015-06-10
+date: 2015-06-09
+acceptance:
+  date: "2015"
+  source_url: "https://neurips.cc/Conferences/2015/Dates"
 venue: NeurIPS
 paper_url: https://proceedings.neurips.cc/paper/2015/hash/29921001f2f04bd3baee84a12e98098f-Abstract.html
 arxiv_url: https://arxiv.org/abs/1506.03134

--- a/specialist/pointerformer.md
+++ b/specialist/pointerformer.md
@@ -13,6 +13,9 @@ authors:
   - "Jiang Bian"
 year: 2023
 date: 2023-04-19
+acceptance:
+  date: "2022-11-18"
+  source_url: "https://aaai-23.aaai.org/aaai23call/"
 venue: "AAAI"
 paper_url: "https://ojs.aaai.org/index.php/AAAI/article/view/25982"
 arxiv_url: "https://arxiv.org/abs/2304.09407"

--- a/specialist/polynet.md
+++ b/specialist/polynet.md
@@ -8,6 +8,9 @@ authors:
   - "Kevin Tierney"
 year: 2025
 date: 2024-02-21
+acceptance:
+  date: "2025-01-22"
+  source_url: "https://iclr.cc/Conferences/2025/Dates"
 venue: "ICLR"
 paper_url: "https://proceedings.iclr.cc/paper_files/paper/2025/hash/c7b9810b2e27bccdc8d605a3a54c8cd6-Abstract-Conference.html"
 arxiv_url: "https://arxiv.org/abs/2402.14048"

--- a/specialist/pomo.md
+++ b/specialist/pomo.md
@@ -11,6 +11,9 @@ authors:
   - Seung-Jai Min
 year: 2020
 date: 2020-10-30
+acceptance:
+  date: "2020-09-26"
+  source_url: "https://neurips.cc/Conferences/2020/Dates"
 venue: NeurIPS
 paper_url: https://proceedings.neurips.cc/paper/2020/hash/f231f2107df69eab0a3862d50018a9b2-Abstract.html
 arxiv_url: https://arxiv.org/abs/2010.16011

--- a/specialist/practical-vrp-joint-learning.md
+++ b/specialist/practical-vrp-joint-learning.md
@@ -12,6 +12,9 @@ authors:
   - Yinghui Xu
 year: 2020
 date: 2020-08-23
+acceptance:
+  date: "2020-05-15"
+  source_url: "https://www.kdd.org/kdd2020/calls/view/kdd-2020-call-for-research-papers.html"
 venue: KDD
 paper_url: https://doi.org/10.1145/3394486.3403356
 institutions:

--- a/specialist/rbg.md
+++ b/specialist/rbg.md
@@ -5,6 +5,9 @@ title: 'RBG: Hierarchically Solving Large-Scale Routing Problems in Logistic Sys
 authors: [Zefang Zong, Hansen Wang, Jingwei Wang, Meng Zheng, Yong Li]
 year: 2022
 date: 2022-08-12
+acceptance:
+  date: "2022-05-18"
+  source_url: "https://kdd.org/kdd2022/cfpResearch.html"
 venue: KDD
 paper_url: https://doi.org/10.1145/3534678.3539037
 institutions: [Tsinghua University, Beijing Tsingroc, Hitachi China Research and Development Corporation]

--- a/specialist/reld.md
+++ b/specialist/reld.md
@@ -8,7 +8,10 @@ authors:
   - "Zhiguang Cao"
   - "Yixin Xu"
 year: 2025
-date: 2024-09-26
+date: 2025-03-02
+acceptance:
+  date: "2025-01-22"
+  source_url: "https://iclr.cc/Conferences/2025/Dates"
 venue: "ICLR"
 paper_url: "https://proceedings.iclr.cc/paper_files/paper/2025/hash/447ac93bf22099aa346a45577376492d-Abstract-Conference.html"
 arxiv_url: "https://arxiv.org/abs/2503.00753"

--- a/specialist/rl-vrp.md
+++ b/specialist/rl-vrp.md
@@ -9,6 +9,9 @@ authors:
   - Lawrence V. Snyder
 year: 2018
 date: 2018-02-12
+acceptance:
+  date: "2018-09-05"
+  source_url: "https://neurips.cc/Conferences/2018/Dates"
 venue: NeurIPS
 paper_url: https://papers.nips.cc/paper_files/paper/2018/hash/9fb4651c05b2ed70fba5afe0b039a550-Abstract.html
 arxiv_url: https://arxiv.org/abs/1802.04240

--- a/specialist/routing-dro.md
+++ b/specialist/routing-dro.md
@@ -5,6 +5,9 @@ title: 'Learning to Solve Routing Problems via Distributionally Robust Optimizat
 authors: [Yuan Jiang, Yaoxin Wu, Zhiguang Cao, Jie Zhang]
 year: 2022
 date: 2022-02-15
+acceptance:
+  date: "2021-11-29"
+  source_url: "https://aaai.org/conference/aaai/aaai-22/"
 venue: AAAI
 paper_url: https://ojs.aaai.org/index.php/AAAI/article/view/21214
 arxiv_url: https://arxiv.org/abs/2202.07241

--- a/specialist/select-and-optimize.md
+++ b/specialist/select-and-optimize.md
@@ -10,6 +10,9 @@ authors:
   - "Shiliang Pu"
 year: 2023
 date: 2023-04-25
+acceptance:
+  date: "2023-01-19"
+  source_url: "https://aistats.org/aistats2023/"
 venue: "AISTATS"
 paper_url: "https://proceedings.mlr.press/v206/cheng23a.html"
 institutions:

--- a/specialist/sil.md
+++ b/specialist/sil.md
@@ -12,6 +12,9 @@ authors:
   - "Qingfu Zhang"
 year: 2025
 date: 2024-09-26
+acceptance:
+  date: "2025-01-22"
+  source_url: "https://iclr.cc/Conferences/2025/Dates"
 venue: "ICLR"
 paper_url: "https://proceedings.iclr.cc/paper_files/paper/2025/hash/264f2e10479c9370972847e96107db7f-Abstract-Conference.html"
 code_url: "https://github.com/CIAM-Group/SIL"

--- a/specialist/simulation-guided-beam-search.md
+++ b/specialist/simulation-guided-beam-search.md
@@ -5,6 +5,9 @@ title: 'Simulation-Guided Beam Search for Neural Combinatorial Optimization'
 authors: [Jinho Choo, Yeong-Dae Kwon, Jihoon Kim, Jeongwoo Jae, André Hottung, Kevin Tierney, Youngjune Gwon]
 year: 2022
 date: 2022-07-13
+acceptance:
+  date: "2022-09-14"
+  source_url: "https://neurips.cc/Conferences/2022/CallForPapers"
 venue: NeurIPS
 paper_url: https://proceedings.neurips.cc/paper_files/paper/2022/hash/39b9b60f0d149eabd1fff2d7c7d5afc4-Abstract-Conference.html
 arxiv_url: https://arxiv.org/abs/2207.06190

--- a/specialist/softdist.md
+++ b/specialist/softdist.md
@@ -11,6 +11,9 @@ authors:
   - "Jiang Bian"
 year: 2024
 date: 2024-06-02
+acceptance:
+  date: "2024-05-01"
+  source_url: "https://icml.cc/Conferences/2024/Dates"
 venue: "ICML"
 paper_url: "https://proceedings.mlr.press/v235/xia24f.html"
 arxiv_url: "https://arxiv.org/abs/2406.03503"

--- a/specialist/step-wise-routing.md
+++ b/specialist/step-wise-routing.md
@@ -5,6 +5,9 @@ title: 'Step-Wise Deep Learning Models for Solving Routing Problems'
 authors: [Liang Xin, Wen Song, Zhiguang Cao, Jie Zhang]
 year: 2021
 date: 2020-10-15
+acceptance:
+  date: "2020"
+  source_url: "https://doi.org/10.1109/TII.2020.3031409"
 venue: IEEE TII
 paper_url: https://doi.org/10.1109/TII.2020.3031409
 institutions: [Nanyang Technological University, National University of Singapore, Shandong University]

--- a/specialist/sym-nco.md
+++ b/specialist/sym-nco.md
@@ -5,6 +5,9 @@ title: 'Sym-NCO: Leveraging Symmetricity for Neural Combinatorial Optimization'
 authors: [Minsu Kim, Junyoung Park, Jinkyoo Park]
 year: 2022
 date: 2022-05-26
+acceptance:
+  date: "2022-09-14"
+  source_url: "https://neurips.cc/Conferences/2022/CallForPapers"
 venue: NeurIPS
 paper_url: https://proceedings.neurips.cc/paper_files/paper/2022/hash/0cddb777d3441326544e21b67f41bdc8-Abstract-Conference.html
 arxiv_url: https://arxiv.org/abs/2205.13209

--- a/specialist/t2t.md
+++ b/specialist/t2t.md
@@ -9,6 +9,9 @@ authors:
   - "Junchi Yan"
 year: 2023
 date: 2023-12-11
+acceptance:
+  date: "2023-09-21"
+  source_url: "https://neurips.cc/Conferences/2023/CallForPapers"
 venue: "NeurIPS"
 paper_url: "https://proceedings.neurips.cc/paper_files/paper/2023/hash/9c93b3cd3bc60c0fe7b0c2d74a2da966-Abstract-Conference.html"
 code_url: "https://github.com/Thinklab-SJTU/T2TCO"

--- a/specialist/tam.md
+++ b/specialist/tam.md
@@ -10,6 +10,9 @@ authors:
   - "Yuming Deng"
 year: 2023
 date: 2023-02-01
+acceptance:
+  date: "2023-01-21"
+  source_url: "https://iclr.cc/Conferences/2023/Dates"
 venue: "ICLR"
 paper_url: "https://openreview.net/forum?id=6ZajpxqTlQ"
 institutions:

--- a/specialist/ttpl.md
+++ b/specialist/ttpl.md
@@ -9,6 +9,9 @@ authors:
   - "Zhenkun Wang"
 year: 2025
 date: 2025-06-03
+acceptance:
+  date: "2025-09-18"
+  source_url: "https://neurips.cc/Conferences/2025/CallForPapers"
 venue: "NeurIPS"
 paper_url: "https://proceedings.neurips.cc/paper_files/paper/2025/hash/6edd46d69ef91f4555d67f7b321d6902-Abstract-Conference.html"
 code_url: "https://github.com/CIAM-Group/TTPL"

--- a/specialist/udc.md
+++ b/specialist/udc.md
@@ -9,7 +9,10 @@ authors:
   - "Mingxuan Yuan"
   - "Zhenkun Wang"
 year: 2024
-date: 2024-07-01
+date: 2024-06-29
+acceptance:
+  date: "2024-09-25"
+  source_url: "https://neurips.cc/Conferences/2024/CallForPapers"
 venue: "NeurIPS"
 paper_url: "https://proceedings.neurips.cc/paper_files/paper/2024/hash/0b8e4c8468273ee3bafb288229c0acbc-Abstract-Conference.html"
 arxiv_url: "https://arxiv.org/abs/2407.00312"

--- a/specialist/utsp.md
+++ b/specialist/utsp.md
@@ -8,6 +8,9 @@ authors:
   - "Carla P. Gomes"
 year: 2023
 date: 2023-03-19
+acceptance:
+  date: "2023-09-21"
+  source_url: "https://neurips.cc/Conferences/2023/CallForPapers"
 venue: "NeurIPS"
 paper_url: "https://proceedings.neurips.cc/paper_files/paper/2023/hash/93b8618a9061f8a55825c13ecf28392b-Abstract-Conference.html"
 arxiv_url: "https://arxiv.org/abs/2303.10538"

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -1,4 +1,4 @@
-import { groupPapersByPublicYear } from '../lib/data'
+import { groupPapersByTimelineYear } from '../lib/data'
 import type { Paper } from '../types'
 import { TimelinePaperCard } from './TimelinePaperCard'
 
@@ -7,12 +7,12 @@ interface TimelineProps {
 }
 
 export function Timeline({ papers }: TimelineProps) {
-  const groups = groupPapersByPublicYear(papers)
+  const groups = groupPapersByTimelineYear(papers)
   let paperIndex = 0
 
   return (
     <div className="timeline-layout">
-      <aside className="year-index" aria-label="Jump to public year">
+      <aside className="year-index" aria-label="Jump to timeline year">
         <span>Year</span>
         {groups.map((group) => <a href={`#year-${group.year}`} key={group.year}>{group.year}</a>)}
       </aside>

--- a/src/components/TimelinePaperCard.tsx
+++ b/src/components/TimelinePaperCard.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom'
-import { compactVenue, formatPublicDate, paradigmLabels, relationCount } from '../lib/data'
+import { formatPartialDate, formatPublicDate, paperTimelineLabel, paradigmLabels, relationCount } from '../lib/data'
 import type { Paper } from '../types'
 import { InstitutionMarks } from './InstitutionMarks'
 
@@ -15,8 +15,10 @@ export function TimelinePaperCard({ paper }: TimelinePaperCardProps) {
       <Link to={`/papers/${paper.id}`} aria-label={`Read the ${paper.short_title} research note`}>
         <div className="timeline-paper-card__topline">
           <InstitutionMarks institutions={paper.institutions} />
-          <span className="timeline-paper-card__public" title={`${formatPublicDate(paper.date)} · ${paper.venue}`}>
-            <time dateTime={paper.date}>{formatPublicDate(paper.date)}</time> · {compactVenue(paper.venue)}
+          <span className="timeline-paper-card__public" title={paperTimelineLabel(paper)}>
+            {paper.acceptance && <time dateTime={paper.acceptance.date}>Accepted {formatPartialDate(paper.acceptance.date)}</time>}
+            {paper.acceptance && paper.arxiv_url && ' · '}
+            {paper.arxiv_url && <time dateTime={paper.date}>arXiv {formatPublicDate(paper.date)}</time>}
           </span>
         </div>
         <h3>{paper.short_title}</h3>

--- a/src/lib/data.test.ts
+++ b/src/lib/data.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from 'vitest'
 import {
+  compactProblemFamily,
   compactVenue,
   filterPapers,
   filtersFromSearchParams,
-  groupPapersByPublicYear,
+  formatPartialDate,
+  groupPapersByTimelineYear,
   institutionInitials,
+  paperTimelineLabel,
   papers,
   relatedPaperId,
   relationKindStyles,
@@ -21,6 +24,7 @@ const base: Paper = {
   authors: ['Ada Researcher'],
   year: 2025,
   date: '2024-01-01',
+  acceptance: { date: '2025-01-22', source_url: 'https://example.com/decision' },
   venue: 'ICLR',
   paper_url: 'https://example.com/paper.pdf',
   institutions: ['Example University'],
@@ -38,10 +42,10 @@ describe('paper filters', () => {
     expect(filterPapers([base], { query, scope: 'all', paradigm: 'all', family: 'all', year: 'all' })).toHaveLength(1)
   })
 
-  it('combines paradigm, family, and public-year filters', () => {
-    expect(filterPapers([base], { query: '', scope: 'specialist', paradigm: 'constructive', family: 'Routing', year: '2024' })).toHaveLength(1)
-    expect(filterPapers([base], { query: '', scope: 'generalist', paradigm: 'constructive', family: 'Routing', year: '2024' })).toHaveLength(0)
-    expect(filterPapers([base], { query: '', scope: 'specialist', paradigm: 'improvement', family: 'Routing', year: '2024' })).toHaveLength(0)
+  it('combines paradigm, family, and timeline-year filters', () => {
+    expect(filterPapers([base], { query: '', scope: 'specialist', paradigm: 'constructive', family: 'Routing', year: '2025' })).toHaveLength(1)
+    expect(filterPapers([base], { query: '', scope: 'generalist', paradigm: 'constructive', family: 'Routing', year: '2025' })).toHaveLength(0)
+    expect(filterPapers([base], { query: '', scope: 'specialist', paradigm: 'improvement', family: 'Routing', year: '2025' })).toHaveLength(0)
   })
 
   it('returns an empty result for a query with no match', () => {
@@ -49,9 +53,9 @@ describe('paper filters', () => {
   })
 
   it('restores valid filter state from a shareable URL and rejects stale values', () => {
-    const options = { scopes: ['specialist', 'generalist'], paradigms: ['constructive'], families: ['Routing'], years: ['2024'] }
-    const restored = filtersFromSearchParams(new URLSearchParams('q=route&scope=specialist&paradigm=constructive&family=Routing&year=2024'), options)
-    expect(restored).toEqual({ query: 'route', scope: 'specialist', paradigm: 'constructive', family: 'Routing', year: '2024' })
+    const options = { scopes: ['specialist', 'generalist'], paradigms: ['constructive'], families: ['Routing'], years: ['2025'] }
+    const restored = filtersFromSearchParams(new URLSearchParams('q=route&scope=specialist&paradigm=constructive&family=Routing&year=2025'), options)
+    expect(restored).toEqual({ query: 'route', scope: 'specialist', paradigm: 'constructive', family: 'Routing', year: '2025' })
 
     const stale = filtersFromSearchParams(new URLSearchParams('scope=archive&paradigm=hybrid&family=Unknown&year=1999'), options)
     expect(stale).toEqual({ query: '', scope: 'all', paradigm: 'all', family: 'all', year: 'all' })
@@ -77,10 +81,11 @@ describe('paper relations', () => {
 })
 
 describe('timeline grouping', () => {
-  it('groups by first-public year and keeps newest years first', () => {
-    const older = { ...base, id: 'older', date: '2021-01-01' }
-    const groups = groupPapersByPublicYear([older, base])
-    expect(groups.map((group) => group.year)).toEqual([2024, 2021])
+  it('groups by acceptance year and falls back to first-public year for arXiv-only work', () => {
+    const older = { ...base, id: 'older', date: '2020-01-01', acceptance: { date: '2021', source_url: 'https://example.com/older-decision' } }
+    const preprint = { ...base, id: 'preprint', date: '2024-03-01', acceptance: undefined, venue: 'arXiv', arxiv_url: 'https://arxiv.org/abs/2403.00001' }
+    const groups = groupPapersByTimelineYear([older, preprint, base])
+    expect(groups.map((group) => group.year)).toEqual([2025, 2024, 2021])
   })
 })
 
@@ -99,6 +104,23 @@ describe('compact paper metadata', () => {
   it('shortens the long workshop venue and preserves other venues', () => {
     expect(compactVenue('AAAI Workshop on Deep Learning on Graphs: Methodologies and Applications')).toBe('AAAI Workshop')
     expect(compactVenue('NeurIPS')).toBe('NeurIPS')
+  })
+
+  it('uses compact academic problem-family labels only for long categories', () => {
+    expect(compactProblemFamily('Multi-objective Optimization')).toBe('Multi-object. Opt.')
+    expect(compactProblemFamily('Generative Optimization')).toBe('Generative Opt.')
+    expect(compactProblemFamily('Robust Optimization')).toBe('Robust Opt.')
+    expect(compactProblemFamily('Graph Optimization')).toBe('Graph Opt.')
+    expect(compactProblemFamily('Subset Selection')).toBe('Subset Sel.')
+    expect(compactProblemFamily('Routing')).toBe('Routing')
+  })
+
+  it('formats accepted and arXiv dates according to their available precision', () => {
+    expect(formatPartialDate('2025')).toBe('2025')
+    expect(formatPartialDate('2025-01')).toBe('Jan 2025')
+    expect(formatPartialDate('2025-01-22')).toBe('Jan 2025')
+    expect(paperTimelineLabel({ ...base, arxiv_url: 'https://arxiv.org/abs/2401.00001' })).toBe('Accepted Jan 2025 · arXiv Jan 2024')
+    expect(paperTimelineLabel({ ...base, acceptance: undefined, venue: 'arXiv', arxiv_url: 'https://arxiv.org/abs/2401.00001' })).toBe('arXiv Jan 2024')
   })
 
   it('derives compact institution marks while ignoring connector words', () => {
@@ -122,6 +144,7 @@ describe('relation graph presentation', () => {
   it('keeps degree-scaled node radii in the compact target range', () => {
     const radius = (degree: number) => Math.sqrt(relationNodeValue(degree)) * relationNodeRelSize
     expect(radius(1)).toBeGreaterThanOrEqual(4)
-    expect(radius(10)).toBeLessThanOrEqual(8)
+    expect(radius(1_000)).toBeLessThanOrEqual(8)
+    expect(relationNodeValue(1_000)).toBe(relationNodeValue(10_000))
   })
 })

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -38,17 +38,29 @@ export const relationKindStyles: Record<RelationKind, RelationKindStyle> = {
 export const relationNodeRelSize = 2.6
 
 export function relationNodeValue(degree: number) {
-  return 2 + degree * 0.55
+  return Math.min(6, 2 + Math.sqrt(degree) * 0.72)
 }
 
 const compactVenueLabels: Record<string, string> = {
   'AAAI Workshop on Deep Learning on Graphs: Methodologies and Applications': 'AAAI Workshop',
 }
 
+const compactProblemFamilyLabels: Record<string, string> = {
+  'Multi-objective Optimization': 'Multi-object. Opt.',
+  'Generative Optimization': 'Generative Opt.',
+  'Robust Optimization': 'Robust Opt.',
+  'Graph Optimization': 'Graph Opt.',
+  'Subset Selection': 'Subset Sel.',
+}
+
 const institutionConnectorWords = new Set(['of', 'and', 'the'])
 
 export function compactVenue(venue: string) {
   return compactVenueLabels[venue] ?? venue
+}
+
+export function compactProblemFamily(problemFamily: string) {
+  return compactProblemFamilyLabels[problemFamily] ?? problemFamily
 }
 
 export function institutionInitials(institution: string) {
@@ -76,9 +88,34 @@ export function publicYear(paper: Paper) {
   return Number(paper.date.slice(0, 4))
 }
 
+export function timelineDate(paper: Paper) {
+  return paper.acceptance?.date ?? paper.date
+}
+
+export function timelineYear(paper: Paper) {
+  return Number(timelineDate(paper).slice(0, 4))
+}
+
 export function formatPublicDate(date: string) {
   return new Intl.DateTimeFormat('en', { month: 'short', year: 'numeric', timeZone: 'UTC' })
     .format(new Date(`${date}T00:00:00Z`))
+}
+
+export function formatPartialDate(date: string) {
+  if (date.length === 4) return date
+  const normalizedDate = date.length === 7 ? `${date}-01` : date
+  return formatPublicDate(normalizedDate)
+}
+
+export function paperTimelineLabel(paper: Paper) {
+  const labels: string[] = []
+  if (paper.acceptance) labels.push(`Accepted ${formatPartialDate(paper.acceptance.date)}`)
+  if (paper.arxiv_url) labels.push(`arXiv ${formatPublicDate(paper.date)}`)
+  return labels.join(' · ')
+}
+
+export function sortPapersByFirstPublicNewestFirst(source: Paper[]) {
+  return [...source].sort((first, second) => second.date.localeCompare(first.date) || first.title.localeCompare(second.title))
 }
 
 export function filterPapers(source: Paper[], filters: PaperFilters) {
@@ -100,7 +137,7 @@ export function filterPapers(source: Paper[], filters: PaperFilters) {
       && (filters.scope === 'all' || paper.scope === filters.scope)
       && (filters.paradigm === 'all' || paper.paradigm === filters.paradigm)
       && (filters.family === 'all' || paper.problem_families.includes(filters.family))
-      && (filters.year === 'all' || publicYear(paper) === Number(filters.year))
+      && (filters.year === 'all' || timelineYear(paper) === Number(filters.year))
   })
 }
 
@@ -126,15 +163,22 @@ export function filtersFromSearchParams(searchParams: Pick<URLSearchParams, 'get
   }
 }
 
-export function groupPapersByPublicYear(source: Paper[]): TimelineGroup[] {
+export function groupPapersByTimelineYear(source: Paper[]): TimelineGroup[] {
   const groups = new Map<number, Paper[]>()
   for (const paper of source) {
-    const year = publicYear(paper)
+    const year = timelineYear(paper)
     groups.set(year, [...(groups.get(year) ?? []), paper])
   }
   return [...groups.entries()]
     .sort(([first], [second]) => second - first)
-    .map(([year, groupedPapers]) => ({ year, papers: groupedPapers }))
+    .map(([year, groupedPapers]) => ({
+      year,
+      papers: [...groupedPapers].sort((first, second) => (
+        timelineDate(second).localeCompare(timelineDate(first))
+        || second.date.localeCompare(first.date)
+        || first.title.localeCompare(second.title)
+      )),
+    }))
 }
 
 export function getPaper(id: string) {

--- a/src/pages/CollectionPage.tsx
+++ b/src/pages/CollectionPage.tsx
@@ -8,9 +8,9 @@ import {
   filtersFromSearchParams,
   papersForScope,
   paradigmLabels,
-  publicYear,
   scopeDescriptions,
   scopeLabels,
+  timelineYear,
   uniqueValues,
 } from '../lib/data'
 import type { PaperFilters, Scope } from '../types'
@@ -23,7 +23,7 @@ export function CollectionPage({ scope }: CollectionPageProps) {
   const [searchParams, setSearchParams] = useSearchParams()
   const source = useMemo(() => papersForScope(scope), [scope])
   const families = useMemo(() => uniqueValues(source.flatMap((paper) => paper.problem_families)), [source])
-  const years = useMemo(() => uniqueValues(source.map((paper) => String(publicYear(paper)))).sort((a, b) => Number(b) - Number(a)), [source])
+  const years = useMemo(() => uniqueValues(source.map((paper) => String(timelineYear(paper)))).sort((a, b) => Number(b) - Number(a)), [source])
   const paradigmValues = Object.keys(paradigmLabels)
 
   const filters = filtersFromSearchParams(searchParams, { paradigms: paradigmValues, families, years })
@@ -65,8 +65,8 @@ export function CollectionPage({ scope }: CollectionPageProps) {
               options: [{ value: 'all', label: 'All problem families' }, ...families.map((value) => ({ value, label: value }))],
             },
             {
-              key: 'year', label: 'First public', value: filters.year,
-              options: [{ value: 'all', label: 'All public years' }, ...years.map((value) => ({ value, label: value }))],
+              key: 'year', label: 'Timeline year', value: filters.year,
+              options: [{ value: 'all', label: 'All timeline years' }, ...years.map((value) => ({ value, label: value }))],
             },
           ]}
           resultCount={filtered.length}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -2,12 +2,12 @@ import { ArrowRight, BookOpenText, Layers3, SearchCheck } from 'lucide-react'
 import { Link } from 'react-router-dom'
 import { PageMeta } from '../components/PageMeta'
 import { PaperCard } from '../components/PaperCard'
-import { papers, papersForScope, scopeDescriptions } from '../lib/data'
+import { papers, papersForScope, scopeDescriptions, sortPapersByFirstPublicNewestFirst } from '../lib/data'
 
 export function HomePage() {
   const specialistCount = papersForScope('specialist').length
   const generalistCount = papersForScope('generalist').length
-  const latest = papers.slice(0, 3)
+  const latest = sortPapersByFirstPublicNewestFirst(papers).slice(0, 3)
 
   return (
     <div className="home-page">

--- a/src/pages/PaperDetailPage.tsx
+++ b/src/pages/PaperDetailPage.tsx
@@ -1,7 +1,7 @@
 import { ArrowLeft, Code2, ExternalLink, FileText } from 'lucide-react'
 import { Link, Navigate, useParams } from 'react-router-dom'
 import { PageMeta } from '../components/PageMeta'
-import { assetUrl, formatPublicDate, getPaper, paradigmLabels, relatedPaperId, relationKindLabels, relationsForPaper, scopeLabels, scopeShortLabels } from '../lib/data'
+import { assetUrl, formatPartialDate, formatPublicDate, getPaper, paradigmLabels, relatedPaperId, relationKindLabels, relationsForPaper, scopeLabels, scopeShortLabels } from '../lib/data'
 
 export function PaperDetailPage() {
   const { id } = useParams()
@@ -14,7 +14,7 @@ export function PaperDetailPage() {
       <PageMeta title={paper.short_title} description={paper.summary} />
       <Link className="back-link" to={`/${paper.scope}`}><ArrowLeft size={15} aria-hidden="true" /> Back to {scopeShortLabels[paper.scope]} timeline</Link>
       <header className="paper-detail__header">
-        <p className="eyebrow">{scopeLabels[paper.scope]} · First public {formatPublicDate(paper.date)}</p>
+        <p className="eyebrow">{scopeLabels[paper.scope]}</p>
         <h1>{paper.title}</h1>
         <p>{paper.authors.join(' · ')}</p>
       </header>
@@ -23,6 +23,8 @@ export function PaperDetailPage() {
         <aside className="paper-metadata" aria-label="Paper metadata">
           <dl>
             <div><dt>Venue</dt><dd>{paper.venue} {paper.year}</dd></div>
+            <div><dt>Accepted</dt><dd>{paper.acceptance ? <a href={paper.acceptance.source_url} target="_blank" rel="noreferrer"><time dateTime={paper.acceptance.date}>{formatPartialDate(paper.acceptance.date)}</time></a> : '—'}</dd></div>
+            <div><dt>Preprint</dt><dd>{paper.arxiv_url ? <a href={paper.arxiv_url} target="_blank" rel="noreferrer"><time dateTime={paper.date}>{formatPublicDate(paper.date)}</time></a> : '—'}</dd></div>
             <div><dt>Scope</dt><dd>{scopeShortLabels[paper.scope]}</dd></div>
             <div><dt>Paradigm</dt><dd>{paradigmLabels[paper.paradigm]}</dd></div>
             <div><dt>Institutions</dt><dd>{paper.institutions.join(' · ')}</dd></div>

--- a/src/pages/PapersPage.tsx
+++ b/src/pages/PapersPage.tsx
@@ -4,14 +4,16 @@ import { FilterBar } from '../components/FilterBar'
 import { InstitutionMarks } from '../components/InstitutionMarks'
 import { PageMeta } from '../components/PageMeta'
 import {
+  compactProblemFamily,
   compactVenue,
   filterPapers,
   filtersFromSearchParams,
+  formatPartialDate,
   formatPublicDate,
   papers,
   paradigmLabels,
-  publicYear,
   scopeShortLabels,
+  timelineYear,
   uniqueValues,
 } from '../lib/data'
 import type { PaperFilters } from '../types'
@@ -19,7 +21,7 @@ import type { PaperFilters } from '../types'
 export function PapersPage() {
   const [searchParams, setSearchParams] = useSearchParams()
   const families = useMemo(() => uniqueValues(papers.flatMap((paper) => paper.problem_families)), [])
-  const years = useMemo(() => uniqueValues(papers.map((paper) => String(publicYear(paper)))).sort((a, b) => Number(b) - Number(a)), [])
+  const years = useMemo(() => uniqueValues(papers.map((paper) => String(timelineYear(paper)))).sort((a, b) => Number(b) - Number(a)), [])
   const filters = filtersFromSearchParams(searchParams, {
     scopes: ['specialist', 'generalist'],
     paradigms: Object.keys(paradigmLabels),
@@ -52,7 +54,7 @@ export function PapersPage() {
             { key: 'scope', label: 'Scope', value: filters.scope, options: [{ value: 'all', label: 'All scopes' }, { value: 'specialist', label: 'Specialist' }, { value: 'generalist', label: 'Generalist' }] },
             { key: 'paradigm', label: 'Paradigm', value: filters.paradigm, options: [{ value: 'all', label: 'All paradigms' }, ...Object.entries(paradigmLabels).map(([value, label]) => ({ value, label }))] },
             { key: 'family', label: 'Problem family', value: filters.family, options: [{ value: 'all', label: 'All problem families' }, ...families.map((value) => ({ value, label: value }))] },
-            { key: 'year', label: 'First public', value: filters.year, options: [{ value: 'all', label: 'All public years' }, ...years.map((value) => ({ value, label: value }))] },
+            { key: 'year', label: 'Timeline year', value: filters.year, options: [{ value: 'all', label: 'All timeline years' }, ...years.map((value) => ({ value, label: value }))] },
           ]}
           resultCount={filtered.length}
           onChange={updateFilter}
@@ -61,7 +63,7 @@ export function PapersPage() {
         {filtered.length > 0 ? (
           <div className="paper-table-wrap">
             <table className="paper-table">
-              <thead><tr><th>Paper</th><th>Institution</th><th>Scope</th><th>Paradigm</th><th>Problem family</th><th>Public</th><th>Venue</th><th>Resources</th></tr></thead>
+              <thead><tr><th>Paper</th><th>Institution</th><th>Scope</th><th>Paradigm</th><th>Problem family</th><th>Accepted</th><th>Preprint</th><th>Venue</th><th>Resources</th></tr></thead>
               <tbody>
                 {filtered.map((paper) => (
                   <tr key={paper.id}>
@@ -69,8 +71,9 @@ export function PapersPage() {
                     <td className="paper-table__institution"><InstitutionMarks institutions={paper.institutions} /></td>
                     <td><span className={`scope-chip scope-chip--${paper.scope}`}>{scopeShortLabels[paper.scope]}</span></td>
                     <td>{paradigmLabels[paper.paradigm]}</td>
-                    <td>{paper.problem_families.join(', ')}</td>
-                    <td><time dateTime={paper.date}>{formatPublicDate(paper.date)}</time></td>
+                    <td className="paper-table__family"><span title={paper.problem_families.join(', ')} aria-label={paper.problem_families.join(', ')}>{paper.problem_families.map(compactProblemFamily).join(', ')}</span></td>
+                    <td className="paper-table__date">{paper.acceptance ? <a href={paper.acceptance.source_url} target="_blank" rel="noreferrer"><time dateTime={paper.acceptance.date}>{formatPartialDate(paper.acceptance.date)}</time></a> : <span aria-label="No formal acceptance">—</span>}</td>
+                    <td className="paper-table__date">{paper.arxiv_url ? <a href={paper.arxiv_url} target="_blank" rel="noreferrer"><time dateTime={paper.date}>{formatPublicDate(paper.date)}</time></a> : <span aria-label="No arXiv preprint">—</span>}</td>
                     <td><span className="paper-table__venue" title={paper.venue}>{compactVenue(paper.venue)}</span></td>
                     <td><div className="table-resources"><a href={paper.paper_url} target="_blank" rel="noreferrer">Paper</a>{paper.code_url && <a href={paper.code_url} target="_blank" rel="noreferrer">Code</a>}<Link to={`/papers/${paper.id}`}>Note</Link></div></td>
                   </tr>

--- a/src/pages/RelationsPage.tsx
+++ b/src/pages/RelationsPage.tsx
@@ -127,7 +127,12 @@ export function RelationsPage() {
   }, [filteredRelations])
 
   const labelledNodeIds = useMemo(() => {
-    const ids = new Set(graphData.nodes.filter((node) => node.degree >= 5).map((node) => node.id))
+    const ids = new Set(
+      [...graphData.nodes]
+        .sort((first, second) => second.degree - first.degree || first.name.localeCompare(second.name))
+        .slice(0, 8)
+        .map((node) => node.id),
+    )
     if (!focusId) return ids
 
     ids.add(focusId)
@@ -141,9 +146,9 @@ export function RelationsPage() {
 
   useEffect(() => {
     const linkForce = graphRef.current?.d3Force('link')
-    linkForce?.distance(width < 600 ? 86 : 132)
+    linkForce?.distance(width < 600 ? 96 : 146)
     const chargeForce = graphRef.current?.d3Force('charge')
-    chargeForce?.strength(width < 600 ? -128 : -225)
+    chargeForce?.strength(width < 600 ? -155 : -270)
     graphRef.current?.d3ReheatSimulation()
   }, [graphData, width])
 
@@ -216,7 +221,7 @@ export function RelationsPage() {
                 linkCurvature={(link: any) => relationKindStyles[link.kind as RelationKind].curvature}
                 linkCanvasObjectMode={() => 'after'}
                 linkCanvasObject={(link: any, context, globalScale) => drawRelationMarker(link, context, globalScale)}
-                cooldownTicks={220}
+                cooldownTicks={260}
                 onEngineStop={() => graphRef.current?.zoomToFit(600, width < 600 ? 54 : 108)}
                 onNodeClick={(node: any) => navigate(`/papers/${node.id}`)}
                 nodeCanvasObjectMode={() => 'after'}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1203,7 +1203,7 @@ select:focus-visible {
 
 .paper-table {
   width: 100%;
-  min-width: 1180px;
+  min-width: 1260px;
   border-collapse: collapse;
   background: rgba(252, 251, 248, 0.52);
   font-size: 0.76rem;
@@ -1234,9 +1234,31 @@ select:focus-visible {
   width: 96px;
 }
 
+.paper-table__family {
+  width: 120px;
+  max-width: 120px;
+}
+
+.paper-table__family span {
+  display: inline-block;
+  max-width: 120px;
+  line-height: 1.35;
+}
+
+.paper-table__date {
+  width: 96px;
+  white-space: nowrap;
+}
+
+.paper-table__date a,
+.paper-metadata dd a {
+  color: var(--accent);
+  border-bottom: 1px solid color-mix(in srgb, var(--accent), transparent 55%);
+}
+
 .paper-table__venue {
   display: inline-block;
-  max-width: 150px;
+  max-width: 130px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,11 @@ export interface PaperFigure {
   source_url: string
 }
 
+export interface PaperAcceptance {
+  date: string
+  source_url: string
+}
+
 export interface Paper {
   id: string
   short_title: string
@@ -16,6 +21,7 @@ export interface Paper {
   authors: string[]
   year: number
   date: string
+  acceptance?: PaperAcceptance
   venue: string
   paper_url: string
   arxiv_url?: string

--- a/tests/content.test.mjs
+++ b/tests/content.test.mjs
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
-import { loadContent, loadPapers, loadRelations, parsePaper, renderMarkdown, sortPapersNewestFirst } from '../scripts/content-lib.mjs'
+import { loadContent, loadPapers, loadRelations, parsePaper, renderMarkdown, sortPapersByFirstPublicNewestFirst, sortPapersNewestFirst } from '../scripts/content-lib.mjs'
 
 const temporaryDirectories = []
 const sections = `
@@ -33,6 +33,7 @@ function paperMarkdown(overrides = {}) {
     authors: ['Ada Researcher'],
     year: 2025,
     date: '2024-03-02',
+    acceptance: { date: '2025-01-22', source_url: 'https://example.com/decision' },
     venue: 'ICLR',
     paper_url: 'https://example.com/paper.pdf',
     institutions: ['Example University'],
@@ -45,8 +46,11 @@ function paperMarkdown(overrides = {}) {
   }
   const lines = ['---']
   for (const [key, value] of Object.entries(metadata)) {
+    if (value === undefined) continue
     if (Array.isArray(value)) {
       lines.push(`${key}:`, ...value.map((item) => `  - ${item}`))
+    } else if (typeof value === 'object' && value !== null) {
+      lines.push(`${key}:`, ...Object.entries(value).map(([nestedKey, nestedValue]) => `  ${nestedKey}: ${nestedValue}`))
     } else {
       lines.push(`${key}: ${value}`)
     }
@@ -89,12 +93,34 @@ describe('paper content schema', () => {
   it('parses unquoted YAML dates and renders a valid paper', () => {
     const paper = parsePaper(paperMarkdown(), { filePath: 'sample-paper.md', expectedScope: 'specialist' })
     expect(paper.date).toBe('2024-03-02')
+    expect(paper.acceptance.date).toBe('2025-01-22')
     expect(paper.body_html).toContain('<h2>Motivation</h2>')
   })
 
   it('rejects invalid dates and paradigms', () => {
     expect(() => parsePaper(paperMarkdown({ date: '2024-02-31' }), { filePath: 'sample-paper.md', expectedScope: 'specialist' })).toThrow()
     expect(() => parsePaper(paperMarkdown({ paradigm: 'hybrid' }), { filePath: 'sample-paper.md', expectedScope: 'specialist' })).toThrow()
+  })
+
+  it('accepts year, month, and day precision for decisions and rejects impossible values', () => {
+    for (const date of ['2025', '2025-01', '2025-01-22']) {
+      const paper = parsePaper(paperMarkdown({ acceptance: { date, source_url: 'https://example.com/decision' } }), { filePath: 'sample-paper.md', expectedScope: 'specialist' })
+      expect(paper.acceptance.date).toBe(date)
+    }
+    expect(() => parsePaper(paperMarkdown({ acceptance: { date: '2025-13', source_url: 'https://example.com/decision' } }), { filePath: 'sample-paper.md', expectedScope: 'specialist' })).toThrow()
+    expect(() => parsePaper(paperMarkdown({ acceptance: { date: '2025-02-31', source_url: 'https://example.com/decision' } }), { filePath: 'sample-paper.md', expectedScope: 'specialist' })).toThrow()
+  })
+
+  it('requires decisions for published work and omits them for arXiv-only papers', () => {
+    expect(() => parsePaper(paperMarkdown({ acceptance: undefined }), { filePath: 'sample-paper.md', expectedScope: 'specialist' })).toThrow('formally published papers must declare acceptance metadata')
+    const preprint = parsePaper(paperMarkdown({ venue: 'arXiv', acceptance: undefined, arxiv_url: 'https://arxiv.org/abs/2403.00001' }), { filePath: 'sample-paper.md', expectedScope: 'specialist' })
+    expect(preprint.acceptance).toBeUndefined()
+    expect(() => parsePaper(paperMarkdown({ venue: 'arXiv' }), { filePath: 'sample-paper.md', expectedScope: 'specialist' })).toThrow('arXiv-only papers must not declare acceptance metadata')
+  })
+
+  it('normalizes Windows line endings before parsing YAML front matter', () => {
+    const paper = parsePaper(paperMarkdown().replaceAll('\n', '\r\n'), { filePath: 'sample-paper.md', expectedScope: 'specialist' })
+    expect(paper.id).toBe('sample-paper')
   })
 
   it('rejects missing required fields, invalid scopes, and invalid URLs', () => {
@@ -173,17 +199,18 @@ describe('relation content schema', () => {
 })
 
 describe('content output', () => {
-  it('builds the repository collection as version 2', async () => {
+  it('builds the repository collection as version 3', async () => {
     const content = await loadContent(path.resolve('.'))
-    expect(content.version).toBe(2)
+    expect(content.version).toBe(3)
     expect(content.relations.length).toBeGreaterThan(0)
   })
-  it('sorts papers by first-public date in descending order', () => {
+  it('sorts collection timelines by acceptance and preserves first-public sorting for the home page', () => {
     const sorted = sortPapersNewestFirst([
-      { id: 'old', title: 'Old', date: '2020-01-01' },
-      { id: 'new', title: 'New', date: '2024-01-01' },
+      { id: 'old', title: 'Old', date: '2020-01-01', acceptance: { date: '2025', source_url: 'https://example.com/old' } },
+      { id: 'new', title: 'New', date: '2024-01-01', acceptance: { date: '2024-05', source_url: 'https://example.com/new' } },
     ])
-    expect(sorted.map((paper) => paper.id)).toEqual(['new', 'old'])
+    expect(sorted.map((paper) => paper.id)).toEqual(['old', 'new'])
+    expect(sortPapersByFirstPublicNewestFirst(sorted).map((paper) => paper.id)).toEqual(['new', 'old'])
   })
 
   it('sanitizes scripts and marks external links safely', () => {

--- a/tests/indexes.test.mjs
+++ b/tests/indexes.test.mjs
@@ -9,6 +9,8 @@ const paper = {
   venue: 'ICLR',
   year: 2025,
   date: '2024-05-01',
+  acceptance: { date: '2025-01-22', source_url: 'https://example.com/decision' },
+  arxiv_url: 'https://arxiv.org/abs/2405.00001',
   institutions: ['Example University'],
 }
 
@@ -17,13 +19,15 @@ describe('README index generation', () => {
     const rendered = renderPaperIndex([paper])
     expect(rendered).toContain('### [Example Paper](example.md)')
     expect(rendered).toContain('- **Paradigm:** Constructive')
+    expect(rendered).toContain('- **Accepted:** [2025-01-22](https://example.com/decision)')
+    expect(rendered).toContain('- **arXiv:** [2024-05-01](https://arxiv.org/abs/2405.00001)')
     expect(rendered).not.toContain('|')
   })
 
-  it('orders entries by first-public date with the newest first', () => {
+  it('orders entries by acceptance date with the newest first', () => {
     const rendered = renderPaperIndex([
-      { ...paper, id: 'older', title: 'Older Paper', date: '2020-01-01' },
-      { ...paper, id: 'newer', title: 'Newer Paper', date: '2025-01-01' },
+      { ...paper, id: 'older', title: 'Older Paper', date: '2025-01-01', acceptance: { date: '2024', source_url: 'https://example.com/older' } },
+      { ...paper, id: 'newer', title: 'Newer Paper', date: '2020-01-01', acceptance: { date: '2025-01', source_url: 'https://example.com/newer' } },
     ])
     expect(rendered.indexOf('Newer Paper')).toBeLessThan(rendered.indexOf('Older Paper'))
   })

--- a/tests/roster.test.mjs
+++ b/tests/roster.test.mjs
@@ -143,12 +143,42 @@ describe('52-paper survey expansion', () => {
     })
   })
 
-  it('connects every added paper with two to four undirected thematic relations', async () => {
+  it('keeps every added paper connected while allowing the curated graph to grow without a maximum', async () => {
     const content = await loadContent(process.cwd())
+    expect(content.relations.length).toBeGreaterThan(155)
     for (const [id] of surveyExpansionRoster) {
       const count = content.relations.filter((relation) => relation.papers.includes(id)).length
-      expect(count, id).toBeGreaterThanOrEqual(2)
-      expect(count, id).toBeLessThanOrEqual(4)
+      expect(count, id).toBeGreaterThan(0)
+    }
+    expect(Math.max(...content.papers.map((paper) => content.relations.filter((relation) => relation.papers.includes(paper.id)).length))).toBeGreaterThan(5)
+  })
+
+  it('records sourced acceptance dates for formal papers and leaves both arXiv-only entries unset', async () => {
+    const { papers } = await loadContent(process.cwd())
+    const formallyPublished = papers.filter((paper) => paper.venue !== 'arXiv')
+    const arxivOnly = papers.filter((paper) => paper.venue === 'arXiv')
+
+    expect(formallyPublished).toHaveLength(90)
+    expect(formallyPublished.every((paper) => /^\d{4}(?:-\d{2}(?:-\d{2})?)?$/.test(paper.acceptance?.date ?? '') && Boolean(paper.acceptance?.source_url))).toBe(true)
+    expect(arxivOnly.map((paper) => paper.id).sort()).toEqual(['efficient-graph-convnet-tsp', 'less-is-more'])
+    expect(arxivOnly.every((paper) => paper.acceptance === undefined)).toBe(true)
+  })
+
+  it('uses arXiv v1 dates when a preprint link is present', async () => {
+    const { papers } = await loadContent(process.cwd())
+    const correctedDates = {
+      agfn: '2025-03-03',
+      reld: '2025-03-02',
+      'fast-t2t': '2025-02-05',
+      udc: '2024-06-29',
+      'graph-guided-local-search': '2021-10-11',
+      'multi-decoder-attention-model': '2020-12-19',
+      'dynamic-am': '2020-02-09',
+      'pointer-networks': '2015-06-09',
+    }
+
+    for (const [id, date] of Object.entries(correctedDates)) {
+      expect(papers.find((paper) => paper.id === id), id).toMatchObject({ date, arxiv_url: expect.stringContaining('arxiv.org/abs/') })
     }
   })
 })

--- a/tests/visual-smoke.mjs
+++ b/tests/visual-smoke.mjs
@@ -59,6 +59,8 @@ try {
     await assertNoHorizontalOverflow(collection, `${viewport.name} collection`)
     const timelineCard = collection.locator('.timeline-paper-card').first()
     await timelineCard.waitFor()
+    if (!/^Accepted |^arXiv /i.test((await timelineCard.locator('.timeline-paper-card__public').innerText()).trim())) throw new Error(`${viewport.name}: timeline card does not expose acceptance/preprint timing`)
+    if (await collection.locator('.select-field', { hasText: 'Timeline year' }).locator('select').count() !== 1) throw new Error(`${viewport.name}: timeline-year filter is missing`)
     if (await timelineCard.locator('.institution-marks').count() !== 1) throw new Error(`${viewport.name}: timeline institution marks were not rendered`)
     const timelineRadius = await timelineCard.evaluate((element) => getComputedStyle(element).borderRadius)
     if (timelineRadius !== '8px') throw new Error(`${viewport.name}: timeline card radius is not 8px`)
@@ -75,7 +77,9 @@ try {
     await papers.goto(`${siteUrl}/papers?scope=generalist&paradigm=constructive`, { waitUntil: 'networkidle' })
     await papers.getByRole('heading', { name: 'All papers' }).waitFor()
     if (await papers.locator('.paper-table tbody tr').count() !== expectedGeneralistConstructiveCount) throw new Error(`${viewport.name}: combined paper filters returned an unexpected result count`)
-    if (await papers.getByRole('columnheader', { name: 'Institution' }).count() !== 1) throw new Error(`${viewport.name}: papers table is missing the Institution column`)
+    const expectedColumns = ['Paper', 'Institution', 'Scope', 'Paradigm', 'Problem family', 'Accepted', 'Preprint', 'Venue', 'Resources']
+    const actualColumns = await papers.locator('.paper-table thead th').allTextContents()
+    if (JSON.stringify(actualColumns) !== JSON.stringify(expectedColumns)) throw new Error(`${viewport.name}: papers table columns are incorrect (${JSON.stringify(actualColumns)})`)
     if (await papers.locator('.paper-table tbody .institution-marks').count() !== expectedGeneralistConstructiveCount) throw new Error(`${viewport.name}: papers table institution marks were not rendered`)
     await assertNoHorizontalOverflow(papers, `${viewport.name} papers`)
     const tableWrap = papers.locator('.paper-table-wrap')
@@ -84,6 +88,19 @@ try {
       if (!scrollable) throw new Error('mobile: paper table should scroll inside its wrapper')
     }
     await papers.screenshot({ path: path.join(artifacts, `papers-${viewport.name}.png`), fullPage: true })
+
+    const compactFamily = await context.newPage()
+    await compactFamily.goto(`${siteUrl}/papers?family=Multi-objective+Optimization`, { waitUntil: 'networkidle' })
+    const familyCell = compactFamily.locator('.paper-table__family').first()
+    await familyCell.waitFor()
+    if (!(await familyCell.innerText()).includes('Multi-object. Opt.')) throw new Error(`${viewport.name}: long problem-family label was not compacted`)
+    if (!(await familyCell.locator('span').getAttribute('title'))?.includes('Multi-objective Optimization')) throw new Error(`${viewport.name}: compact problem-family label lost its full tooltip`)
+
+    const arxivOnly = await context.newPage()
+    await arxivOnly.goto(`${siteUrl}/papers?q=Less+Is+More`, { waitUntil: 'networkidle' })
+    const arxivOnlyCells = arxivOnly.locator('.paper-table tbody tr').first().locator('th, td')
+    if ((await arxivOnlyCells.nth(5).innerText()).trim() !== '—') throw new Error(`${viewport.name}: arXiv-only paper must show an empty Accepted value`)
+    if (!(await arxivOnlyCells.nth(6).innerText()).includes('Mar 2024')) throw new Error(`${viewport.name}: arXiv-only paper is missing its Preprint date`)
 
     const relationPage = await context.newPage()
     await relationPage.goto(`${siteUrl}/relations`, { waitUntil: 'networkidle' })
@@ -99,6 +116,7 @@ try {
     const detail = await context.newPage()
     await detail.goto(`${siteUrl}/papers/attention-model`, { waitUntil: 'networkidle' })
     await detail.getByRole('heading', { name: 'Motivation' }).waitFor()
+    if (await detail.locator('.paper-metadata dt', { hasText: 'Accepted' }).count() !== 1 || await detail.locator('.paper-metadata dt', { hasText: 'Preprint' }).count() !== 1) throw new Error(`${viewport.name}: detail metadata does not separate Accepted and Preprint`)
     await detail.locator('.paper-figure img').waitFor()
     const imageLoaded = await detail.locator('.paper-figure img').evaluate((image) => image.complete && image.naturalWidth > 0)
     if (!imageLoaded) throw new Error(`${viewport.name}: framework image did not load`)


### PR DESCRIPTION
## Summary

- upgrades generated content to `version: 3` and adds sourced, partial-precision acceptance metadata
- records acceptance dates for all 90 formally published papers; keeps `Less Is More` and `Efficient Graph Convolutional Network for the Traveling Salesman Problem` as arXiv-only
- drives Specialist/Generalist timelines and the existing `year` filter from acceptance dates, with arXiv fallback, while keeping Home's recent work ordered by first-public date
- splits Papers and paper-detail metadata into `Accepted` and `Preprint`; adds compact problem-family labels such as `Multi-object. Opt.` and constrained column widths
- preserves all 155 existing relations and adds 104 curated links (259 total), without a relationship-count cap; every paper currently has at least five relations
- limits persistent graph labels to the eight highest-degree nodes, then shows the focused paper and all direct neighbors

## Metadata notes

- acceptance dates retain only the precision supported by the cited source (`YYYY`, `YYYY-MM`, or `YYYY-MM-DD`)
- arXiv dates remain first-public/v1 dates and were audited against the arXiv API for all 71 linked preprints
- workshop decisions for GPN/HGPN and EGATE use their published notification dates

## Validation

- `npm run sync`
- `npm run validate` — 92 papers, 259 relations
- `npm test` — 48 tests passed
- `npm run build`
- `npm run visual` — desktop and 390px mobile smoke checks passed