### PR TITLE
完善 LIH 和 DACT 两篇论文笔记

### DIFF
--- a/data/relations.yml
+++ b/data/relations.yml
@@ -181,7 +181,7 @@ relations:
     description: Both encode changing vehicle state during construction, for a single route context and cooperative multi-vehicle agents respectively.
   - papers: [learning-improvement-heuristics, dact]
     kind: architecture
-    description: Both use attention-based actors for repeated pairwise routing improvements and maintain search-history information.
+    description: Both learn attention-based policies for repeated pairwise routing improvements; DACT replaces LIH's single-stream representation and recurrent search signal with dual node-position streams and cyclic positional encoding.
   - papers: [learning-improvement-heuristics, graph-guided-local-search]
     kind: search
     description: Both learn which parts of a current tour deserve modification, coupled with neural moves and Guided Local Search.

--- a/specialist/dact.md
+++ b/specialist/dact.md
@@ -54,22 +54,27 @@ Transformers are effective construction models, but standard positional encoding
 - Introduces cyclic positional encoding to represent the rotation and reflection symmetries of routing solutions.
 - Uses a dual-aspect decoder to combine action proposals derived from node and positional views.
 - Introduces a curriculum-learning strategy for more stable and sample-efficient PPO training.
+- Evaluates both representation and training choices through ablations on dual-aspect encoding, cyclic positional encoding, and curriculum learning.
 
 ## Methodology
 
 1. The current route is represented through node features and positions in the cyclic solution.
-2. Two embedding streams encode node and positional information separately.
-3. Collaborative attention lets each stream refer to the other without prematurely merging their representations.
-4. The decoder produces a distribution over pairwise local actions that modify the current solution.
-5. The policy is trained with n-step Proximal Policy Optimization and a curriculum over improvement horizons.
-6. At inference, the learned operator is applied iteratively, optionally with augmentation and a larger step budget.
+2. Node feature embeddings and positional feature embeddings are encoded in separate streams.
+3. Cyclic positional encoding represents route positions so adjacent positions across the tour boundary remain close in the positional representation.
+4. Dual-aspect collaborative attention lets each stream refer to the other while avoiding premature fusion of node and position correlations.
+5. The decoder generates node-pair action proposals from both aspects and aggregates them into a distribution over pairwise local actions.
+6. Infeasible node pairs, diagonal choices, and immediately repeated node pairs are masked before sampling or selecting a move.
+7. The policy is trained with n-step Proximal Policy Optimization and a curriculum that gradually exposes the agent to higher-quality initial states.
+8. At inference, the learned operator is applied iteratively, optionally with augmentation and a larger step budget.
 
 ## Experiments
 
 - **Problems:** TSP and CVRP
 - **Synthetic sizes:** Primarily 20, 50, and 100 nodes/customers
+- **Initial solutions:** Uses randomly generated initial solutions during training and greedy solutions during inference.
+- **Search budget:** Reports results with iterative limits such as 5,000 and 10,000 steps, with optional data augmentation for stronger inference.
 - **Benchmark data:** TSPLIB and CVRPLIB, including instances larger than the main training sizes
-- **Main baselines:** Transformer-based improvement models, construction models, OR-Tools, LKH, and other learned search methods
+- **Main baselines:** Transformer-based improvement models, construction models, OR-Tools, LKH, Concorde for TSP, and other learned search methods
 - **Metrics:** Objective value, optimality gap, runtime, and cross-size generalization
 - **Ablations:** Dual-aspect representation, cyclic positional encoding, and curriculum learning
 - **Main finding:** DACT improves over the compared Transformer-based improvement methods and shows stronger cross-size and benchmark generalization, at the cost of iterative inference.
@@ -91,7 +96,7 @@ Author-reported constraints and curator observations are separated to keep inter
 
 ## Reproducibility
 
-- Official implementation: [yining043/VRP-DACT](https://github.com/yining043/VRP-DACT)
-- Pretrained checkpoints: available
-- Notebook/demo: available
-- Main paper references: Sections 3-5 and Appendices C-E
+- **Official implementation:** [yining043/VRP-DACT](https://github.com/yining043/VRP-DACT)
+- **Checkpoints:** Available in the official repository.
+- **Notebook/demo:** Available in the official repository.
+- **Main paper references:** Sections 3-5 and Appendices C-E.

--- a/specialist/learning-improvement-heuristics.md
+++ b/specialist/learning-improvement-heuristics.md
@@ -31,37 +31,50 @@ summary: LIH learns pairwise routing moves with a graph-attention actor and impr
 
 ## Motivation
 
-Construction policies cannot revise decisions, while manually tuned local search lacks data-driven move selection. The paper focuses learning on the choice of improvement moves rather than complete solutions.
+Construction policies produce complete solutions but cannot directly revise earlier decisions. Classical improvement heuristics can refine incumbents through local search, yet their move-selection rules are usually hand crafted and can depend heavily on expert design. LIH focuses learning on the improvement stage, using reinforcement learning to choose local moves that iteratively improve an initial routing solution.
 
 ## Contributions
 
 - Proposes a graph-attention improvement policy for TSP and CVRP.
+- Formulates iterative local search as a reinforcement-learning task over routing solutions and pairwise local actions.
 - Adds a recurrent state mechanism to summarize recent search behavior.
 - Trains the policy with actor-critic reinforcement learning over multi-step improvement trajectories.
+- Studies generalization across initial solutions, problem sizes, and public benchmark instances.
 
 ## Methodology
 
-1. Encode nodes, current tour adjacency, and routing state. 2. Select two positions with attention. 3. Apply the corresponding pairwise exchange/reconnection. 4. Update the recurrent search state and incumbent; repeat for the test budget.
+1. Formulate improvement search as a continuing reinforcement-learning task over incumbent routing solutions.
+2. Represent each action as a pair of nodes selected for a local operator.
+3. Use a self-attention policy network to embed the current solution and score all candidate node pairs.
+4. Mask infeasible or immediately reversing node-pair choices before sampling an action.
+5. Apply the selected pairwise operator, using 2-opt as the default operator after comparing 2-opt, node swap, and relocation.
+6. Always accept the resulting state during the search, while retaining the best incumbent solution found so far.
+7. Train the actor with an n-step actor-critic algorithm and a critic baseline for reward estimation.
 
 ## Experiments
 
 - **Problems:** TSP and CVRP, chiefly 20-, 50-, and 100-node/customer synthetic sets plus generalization tests.
-- **Baselines:** Neural constructors, classical local search, and learned improvement policies.
-- **Metrics:** Best objective/gap over iterations and runtime.
-- **Main finding:** Learned move selection improves incumbents throughout the allotted horizon; longer rollouts yield better routes but make one-shot runtime comparisons inappropriate.
+- **Training instances:** Random Euclidean instances generated on the fly; TSP starts from random initial tours, while CVRP starts from nearest-insertion solutions with dummy depots for batching.
+- **Search budget:** Reports iterative search with step limits such as 1,000, 3,000, and 5,000, plus multi-run and multi-policy diversification strategies.
+- **Baselines:** Concorde, LKH3, OR-Tools, Attention Model sampling, NeuRewriter, and simple 2-opt hand-crafted policies.
+- **Metrics:** Best objective value, optimality gap, and total runtime over the test set.
+- **Generalization:** Tests transfer across initial solutions, problem sizes, and public TSPLIB/CVRPLIB instances.
+- **Main finding:** Learned move selection improves incumbents throughout the allotted horizon; longer rollouts and diversification improve quality, but inference-budget differences make one-shot runtime comparisons inappropriate.
 
 ## Limitations
 
 ### Reported by the Authors
 
 - Iterative search requires many sequential policy evaluations.
+- The paper uses a simple always-accept search scheme and mainly reports 2-opt, leaving multiple-operator policies and more advanced search schemes as future work.
 
 ### Curator Notes
 
 - Separate task models and fixed neighborhood definitions limit cross-problem reuse.
+- The strongest reported configurations use larger step limits or multiple runs, so comparisons should match the allowed inference budget.
 
 ## Reproducibility
 
 - **Official implementation:** [WXY1427/Learn-Improvement-Heuristics-for-Routing](https://github.com/WXY1427/Learn-Improvement-Heuristics-for-Routing)
 - **Checkpoints:** See the official repository.
-- **Main paper references:** Actor architecture, improvement algorithm, and Tables II–VI.
+- **Main paper references:** Sections IV-V and Tables I-V.


### PR DESCRIPTION
## Summary

对仓库中已有的 LIH 和 DACT 两篇论文笔记做了小幅完善，主要包括：

- 补充更清晰的 methodology 描述。
- 补充实验设置、搜索预算和泛化测试相关信息。
- 统一 DACT 的 reproducibility 格式。
- 更新 `relations.yml` 中 LIH 与 DACT 的关系描述，使其更准确。

## Checklist

- [x] Paper `id` matches its filename.
- [x] Scope and paradigm follow the repository definitions.
- [x] Front Matter includes every required field.
- [x] The note includes all required research sections.
- [x] Claims are neutral and traceable to original sources.
- [x] Generated README index blocks and `src/generated/` were not edited manually.
- [x] `npm run validate`, `npm test`, and `npm run build` pass locally.